### PR TITLE
hide ReadyToUpgradeCmdletParameter cause we couldn't auto fix it

### DIFF
--- a/vscode-extension/server/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
+++ b/vscode-extension/server/src/PowerShellEditorServices/Services/Analysis/PssaCmdletAnalysisEngine.cs
@@ -364,8 +364,13 @@ namespace Microsoft.PowerShell.EditorServices.Services.Analysis
             {
                 // scriptMarkers[i] = ScriptFileMarker.FromDiagnosticRecord(diagnostic);
                 scriptMarkers[i] = ScriptFileMarker.FromUpgradePlan(diagnostic);
-                i++;
+                if (scriptMarkers[i].RuleName != "ReadyToUpgradeCmdletParameter")
+                {
+                    i++;
+                }
             }
+
+            Array.Resize(ref scriptMarkers, i);
 
             return scriptMarkers;
         }


### PR DESCRIPTION
Our current extension couldn't handle cmdlet parameter now, in order not to confuse customer, hide it temporary.