### PR TITLE
Updated docs to remove warnings about splatting support

### DIFF
--- a/docs/quickstart-migrate-azurerm-to-az-automatically.md
+++ b/docs/quickstart-migrate-azurerm-to-az-automatically.md
@@ -104,8 +104,6 @@ $Results | Where-Object UpgradeResult -ne UpgradeCompleted | Format-List
 
 ## Limitations
 
-* Automated parameter name updates to splatted parameter sets aren't supported. If any are found
-  during upgrade plan generation, a warning is returned.
 * File I/O operations use default encoding. Unusual file encoding situations may cause problems.
 * AzureRM cmdlets passed as arguments to Pester unit test mock statements aren't detected.
 * Currently, only Az PowerShell module version 5.2.0 is supported as a target.

--- a/powershell-module/README.md
+++ b/powershell-module/README.md
@@ -74,7 +74,5 @@ $results | where UpgradeResult -ne UpgradeCompleted | format-list
 
 ## Limitations
 
-* Automated parameter name updates to splatted parameter sets aren't supported. If any are found
-  during upgrade plan generation, a warning is returned.
 * File I/O operations use default encoding. Unusual file encoding situations may cause problems.
 * AzureRM cmdlets passed as arguments to Pester unit test mock statements aren't detected.


### PR DESCRIPTION
Splatted parameter detection is implemented in 1.0 and later. Now that 1.0 is published to PSGallery, we can remove the doc warnings about support for this feature.