### PR TITLE
Bugfix #73: Object member hashtable detection updates

### DIFF
--- a/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting6.ps1
+++ b/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting6.ps1
@@ -1,4 +1,4 @@
-# example 1: hashtable splatted arguments with an ordered hashtable (supported)
+# example 6: hashtable splatted arguments with an ordered hashtable (supported)
 $splattedParams = [ordered]@{
     TargetName = $TargetName
     Count = 5

--- a/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting7.ps1
+++ b/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting7.ps1
@@ -1,0 +1,10 @@
+# example 7: tests for GitHub issue #73
+# assigning a hashtable to an object property (member) shouldn't break the splatted parameter detection.
+
+$testObject.Property1 = @{ key1 = $value1 }
+
+if ($true) {
+    $testObject.Property2 += @{ key2 = $value2 }
+}
+
+Test-Connection -TargetName $TargetName -IPv4 -Count 5

--- a/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting8.ps1
+++ b/powershell-module/Az.Tools.Migration/Resources/TestFiles/ScriptExample-ParameterSplatting8.ps1
@@ -1,0 +1,12 @@
+# example 8: tests for GitHub issue #73
+# assigning a nested hashtable to an object property (member) shouldn't break the splatted parameter detection.
+
+if ($true) {
+    $testObject.Property1 = @{
+        NestedTable = @{
+            NestedProperty = $true
+        }
+    }
+}
+
+Test-Connection -TargetName $TargetName -IPv4 -Count 5

--- a/powershell-module/Az.Tools.Migration/Tests/Functions/Private/Find-CmdletsInFile.tests.ps1
+++ b/powershell-module/Az.Tools.Migration/Tests/Functions/Private/Find-CmdletsInFile.tests.ps1
@@ -664,5 +664,31 @@ InModuleScope -ModuleName Az.Tools.Migration -ScriptBlock {
             $results[0].Parameters[0].StartOffset | Should Be 194
             $results[0].Parameters[0].EndOffset | Should Be 199
         }
+        It 'Should safely skip hashtable assignments to object members' {
+            # arrange
+            $testFile = Resolve-Path -Path ".\Resources\TestFiles\ScriptExample-ParameterSplatting7.ps1"
+
+            # act
+            # this should not throw an exception.
+            $results = Find-CmdletsInFile -FilePath $testFile.Path
+
+            # assert
+            $results | Should Not Be Null
+            $results.Count | Should Be 1
+            $results[0].CommandName | Should Be "Test-Connection"
+        }
+        It 'Should safely skip nested hashtable assignments to object members' {
+            # arrange
+            $testFile = Resolve-Path -Path ".\Resources\TestFiles\ScriptExample-ParameterSplatting8.ps1"
+
+            # act
+            # this should not throw an exception.
+            $results = Find-CmdletsInFile -FilePath $testFile.Path
+
+            # assert
+            $results | Should Not Be Null
+            $results.Count | Should Be 1
+            $results[0].CommandName | Should Be "Test-Connection"
+        }
     }
 }


### PR DESCRIPTION
* Added safety check to ensure splatted parameter scans are looking for variable expressions only (`VariableExpressionAst`), and to skip member expression ASTs. This fixes bug #73.

* Added two more unit tests that cover the member expression detection break.

Unit tests passing w/ new tests:

![image](https://user-images.githubusercontent.com/9817416/104670512-d4c6a680-5690-11eb-95c5-675dff5e72dd.png)
