### PR TITLE
Improved handling for cmdlets with dynamic parameters

### DIFF
--- a/common/code-upgrade-samples/az/dynamic-parameters-test1.ps1
+++ b/common/code-upgrade-samples/az/dynamic-parameters-test1.ps1
@@ -1,0 +1,7 @@
+# dynamic params example 1: a mix of known parameters and user / dynamic parameters should be supported, but provide a warning instead of an error.
+
+New-AzResourceGroupDeployment -ResourceGroupName "ContosoEngineering" `
+    -TemplateFile "D:\Azure\Templates\EngineeringSite.json" `
+    -TemplateParameterFile "D:\Azure\Templates\EngSiteParms.json" `
+    - "test1" `
+    - "test2"

--- a/common/code-upgrade-samples/azurerm/dynamic-parameters-test1.ps1
+++ b/common/code-upgrade-samples/azurerm/dynamic-parameters-test1.ps1
@@ -1,0 +1,7 @@
+# dynamic params example 1: a mix of known parameters and user / dynamic parameters should be supported, but provide a warning instead of an error.
+
+New-AzureRmResourceGroupDeployment -ResourceGroupName "ContosoEngineering" `
+    -TemplateFile "D:\Azure\Templates\EngineeringSite.json" `
+    -TemplateParameterFile "D:\Azure\Templates\EngSiteParms.json" `
+    -DynamicUserParam1 "test1" `
+    -DynamicUserParam2 "test2"

--- a/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
+++ b/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
@@ -90,7 +90,7 @@ Enum PlanResultReasonCode
     ErrorNoUpgradeAlias = 2
     ErrorNoModuleSpecMatch = 3
     ErrorParameterNotFound = 4
-    WarningDynamicParameters = 5
+    WarningDynamicParameter = 5
 }
 
 Enum UpgradeResultReasonCode

--- a/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
+++ b/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
@@ -30,14 +30,10 @@ class CommandDefinition
 {
     [System.String] $Command
     [System.Boolean] $IsAlias
+    [System.Boolean] $SupportsDynamicParameters
     [System.String] $SourceModule
     [System.String] $Version
     [System.Collections.Generic.List[CommandDefinitionParameter]] $Parameters
-
-    CommandDefinition()
-    {
-        $this.Parameters = New-Object -TypeName 'System.Collections.Generic.List[CommandDefinitionParameter]'
-    }
 }
 
 class CommandReferenceParameter
@@ -94,6 +90,7 @@ Enum PlanResultReasonCode
     ErrorNoUpgradeAlias = 2
     ErrorNoModuleSpecMatch = 3
     ErrorParameterNotFound = 4
+    WarningDynamicParameters = 5
 }
 
 Enum UpgradeResultReasonCode

--- a/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
+++ b/powershell-module/Az.Tools.Migration/Classes/Classes.ps1
@@ -157,7 +157,7 @@ class UpgradeResult
 
         if ($Plan.PlanSeverity -eq [DiagnosticSeverity]::Warning)
         {
-            $this.UpgradeResult = [UpgradeResultReasonCode]::UpgradedWithWarnings
+            $this.UpgradeResult = [UpgradeResultReasonCode]::UnableToUpgrade
             $this.UpgradeResultReason = $Plan.PlanResultReason
             $this.UpgradeSeverity = [DiagnosticSeverity]::Warning
         }

--- a/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
+++ b/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
@@ -311,7 +311,7 @@ function New-AzUpgradeModulePlan
                         $paramWarning.StartOffset = $rmParam.StartOffset
                         $paramWarning.SourceCommandParameter = $rmParam
                         $paramWarning.Location = $rmParam.Location
-                        $paramWarning.PlanResultReason = "Parameter is dynamic, or was not found in $resolvedCommandName or its aliases, requires review."
+                        $paramWarning.PlanResultReason = "Parameter was not found in $resolvedCommandName or its aliases, but this may not be a problem because this cmdlet also supports dynamic parameters."
                         $paramWarning.PlanResult = [PlanResultReasonCode]::WarningDynamicParameter
                         $paramWarning.PlanSeverity = [DiagnosticSeverity]::Warning
 
@@ -327,7 +327,7 @@ function New-AzUpgradeModulePlan
                         $paramError.StartOffset = $rmParam.StartOffset
                         $paramError.SourceCommandParameter = $rmParam
                         $paramError.Location = $rmParam.Location
-                        $paramError.PlanResultReason = "Parameter was not found in $resolvedCommandName or its aliases."
+                        $paramError.PlanResultReason = "Parameter was not found in $resolvedCommandName or its aliases. This may indicate a breaking change that requires attention."
                         $paramError.PlanResult = [PlanResultReasonCode]::ErrorParameterNotFound
                         $paramError.PlanSeverity = [DiagnosticSeverity]::Error
     

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Accounts.2.2.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Accounts.2.2.2.Cmdlets.json
@@ -2,8 +2,9 @@
   {
     "Command": "Disable-AzDataCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "DefaultProfile",
@@ -30,8 +31,9 @@
   {
     "Command": "Disable-AzContextAutosave",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Scope",
@@ -62,8 +64,9 @@
   {
     "Command": "Enable-AzDataCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "DefaultProfile",
@@ -90,8 +93,9 @@
   {
     "Command": "Enable-AzContextAutosave",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Scope",
@@ -122,8 +126,9 @@
   {
     "Command": "Remove-AzEnvironment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Name",
@@ -158,8 +163,9 @@
   {
     "Command": "Get-AzEnvironment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Name",
@@ -178,8 +184,9 @@
   {
     "Command": "Set-AzEnvironment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Name",
@@ -365,8 +372,9 @@
   {
     "Command": "Add-AzEnvironment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Name",
@@ -560,8 +568,9 @@
   {
     "Command": "Get-AzSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "SubscriptionId",
@@ -592,8 +601,9 @@
   {
     "Command": "Connect-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Environment",
@@ -723,8 +733,9 @@
   {
     "Command": "Get-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "ListAvailable",
@@ -751,8 +762,9 @@
   {
     "Command": "Set-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Context",
@@ -821,8 +833,9 @@
   {
     "Command": "Import-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "AzureContext",
@@ -863,8 +876,9 @@
   {
     "Command": "Save-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Profile",
@@ -903,8 +917,9 @@
   {
     "Command": "Get-AzTenant",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "TenantId",
@@ -926,8 +941,9 @@
   {
     "Command": "Send-Feedback",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "DefaultProfile",
@@ -942,8 +958,9 @@
   {
     "Command": "Resolve-AzError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Error",
@@ -966,8 +983,9 @@
   {
     "Command": "Select-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "InputObject",
@@ -1006,8 +1024,9 @@
   {
     "Command": "Rename-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "InputObject",
@@ -1058,8 +1077,9 @@
   {
     "Command": "Remove-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "InputObject",
@@ -1106,8 +1126,9 @@
   {
     "Command": "Clear-AzContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "PassThru",
@@ -1146,8 +1167,9 @@
   {
     "Command": "Disconnect-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Username",
@@ -1208,8 +1230,9 @@
   {
     "Command": "Get-AzContextAutosaveSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Scope",
@@ -1228,8 +1251,9 @@
   {
     "Command": "Set-AzDefault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "ResourceGroupName",
@@ -1268,8 +1292,9 @@
   {
     "Command": "Get-AzDefault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "ResourceGroup",
@@ -1288,8 +1313,9 @@
   {
     "Command": "Clear-AzDefault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "ResourceGroup",
@@ -1332,8 +1358,9 @@
   {
     "Command": "Register-AzModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "WhatIf",
@@ -1352,8 +1379,9 @@
   {
     "Command": "Enable-AzureRmAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Scope",
@@ -1392,8 +1420,9 @@
   {
     "Command": "Disable-AzureRmAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Scope",
@@ -1432,8 +1461,9 @@
   {
     "Command": "Uninstall-AzureRm",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "PassThru",
@@ -1464,8 +1494,9 @@
   {
     "Command": "Invoke-AzRestMethod",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "SubscriptionId",
@@ -1532,8 +1563,9 @@
   {
     "Command": "Get-AzAccessToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "ResourceUrl",
@@ -1563,8 +1595,9 @@
   {
     "Command": "Add-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Environment",
@@ -1694,8 +1727,9 @@
   {
     "Command": "Login-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Environment",
@@ -1825,8 +1859,9 @@
   {
     "Command": "Remove-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Username",
@@ -1887,8 +1922,9 @@
   {
     "Command": "Logout-AzAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Username",
@@ -1949,8 +1985,9 @@
   {
     "Command": "Select-AzSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Context",
@@ -2019,8 +2056,9 @@
   {
     "Command": "Resolve-Error",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Error",
@@ -2043,8 +2081,9 @@
   {
     "Command": "Save-AzProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "Profile",
@@ -2083,8 +2122,9 @@
   {
     "Command": "Get-AzDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "TenantId",
@@ -2106,8 +2146,9 @@
   {
     "Command": "Invoke-AzRest",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Accounts",
-    "Version": "2.2.2",
+    "Version": "2.2.3",
     "Parameters": [
       {
         "Name": "SubscriptionId",

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Advisor.1.1.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Advisor.1.1.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzAdvisorRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Advisor",
     "Version": "1.1.1",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "Enable-AzAdvisorRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Advisor",
     "Version": "1.1.1",
     "Parameters": [
@@ -70,6 +72,7 @@
   {
     "Command": "Disable-AzAdvisorRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Advisor",
     "Version": "1.1.1",
     "Parameters": [
@@ -114,6 +117,7 @@
   {
     "Command": "Get-AzAdvisorConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Advisor",
     "Version": "1.1.1",
     "Parameters": [
@@ -134,6 +138,7 @@
   {
     "Command": "Set-AzAdvisorConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Advisor",
     "Version": "1.1.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Aks.2.0.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Aks.2.0.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzAksCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -32,6 +33,7 @@
   {
     "Command": "New-AzAksCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -200,6 +202,7 @@
   {
     "Command": "Remove-AzAksCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -258,6 +261,7 @@
   {
     "Command": "Import-AzAksCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -320,6 +324,7 @@
   {
     "Command": "Start-AzAksDashboard",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -366,6 +371,7 @@
   {
     "Command": "Stop-AzAksDashboard",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -386,6 +392,7 @@
   {
     "Command": "Set-AzAksCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -500,6 +507,7 @@
   {
     "Command": "New-AzAksNodePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -600,6 +608,7 @@
   {
     "Command": "Update-AzAksNodePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -678,6 +687,7 @@
   {
     "Command": "Remove-AzAksNodePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -744,6 +754,7 @@
   {
     "Command": "Get-AzAksNodePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -782,6 +793,7 @@
   {
     "Command": "Install-AzAksKubectl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -834,6 +846,7 @@
   {
     "Command": "Get-AzAksVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -854,6 +867,7 @@
   {
     "Command": "Enable-AzAksAddOn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -906,6 +920,7 @@
   {
     "Command": "Disable-AzAksAddOn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -950,6 +965,7 @@
   {
     "Command": "Get-AzAks",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -980,6 +996,7 @@
   {
     "Command": "New-AzAks",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -1148,6 +1165,7 @@
   {
     "Command": "Remove-AzAks",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [
@@ -1206,6 +1224,7 @@
   {
     "Command": "Set-AzAks",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Aks",
     "Version": "2.0.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.AnalysisServices.1.1.4.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.AnalysisServices.1.1.4.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Resume-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -42,6 +43,7 @@
   {
     "Command": "Suspend-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -82,6 +84,7 @@
   {
     "Command": "Get-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -106,6 +109,7 @@
   {
     "Command": "Remove-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -146,6 +150,7 @@
   {
     "Command": "Set-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -226,6 +231,7 @@
   {
     "Command": "Test-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -250,6 +256,7 @@
   {
     "Command": "New-AzAnalysisServicesServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -322,6 +329,7 @@
   {
     "Command": "New-AzAnalysisServicesFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -350,6 +358,7 @@
   {
     "Command": "New-AzAnalysisServicesFirewallConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -374,6 +383,7 @@
   {
     "Command": "Add-AzAnalysisServicesAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -418,6 +428,7 @@
   {
     "Command": "Restart-AzAnalysisServicesInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -446,6 +457,7 @@
   {
     "Command": "Export-AzAnalysisServicesInstanceLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -482,6 +494,7 @@
   {
     "Command": "Sync-AzAnalysisServicesInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -514,6 +527,7 @@
   {
     "Command": "Resume-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -554,6 +568,7 @@
   {
     "Command": "Suspend-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -594,6 +609,7 @@
   {
     "Command": "Get-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -618,6 +634,7 @@
   {
     "Command": "Remove-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -658,6 +675,7 @@
   {
     "Command": "Set-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -738,6 +756,7 @@
   {
     "Command": "Test-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -762,6 +781,7 @@
   {
     "Command": "New-AzAs",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -834,6 +854,7 @@
   {
     "Command": "Login-AzAsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -878,6 +899,7 @@
   {
     "Command": "Login-AzureAsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -922,6 +944,7 @@
   {
     "Command": "Export-AzAsInstanceLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -958,6 +981,7 @@
   {
     "Command": "Export-AzureAsInstanceLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -994,6 +1018,7 @@
   {
     "Command": "Sync-AzAsInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -1026,6 +1051,7 @@
   {
     "Command": "Sync-AzureAsInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -1058,6 +1084,7 @@
   {
     "Command": "Restart-AzAsInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [
@@ -1086,6 +1113,7 @@
   {
     "Command": "Restart-AzureAsInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AnalysisServices",
     "Version": "1.1.4",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ApiManagement.2.2.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ApiManagement.2.2.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzApiManagementApiToGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -50,6 +51,7 @@
   {
     "Command": "Add-AzApiManagementApiToProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -82,6 +84,7 @@
   {
     "Command": "Add-AzApiManagementProductToGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -114,6 +117,7 @@
   {
     "Command": "Add-AzApiManagementRegion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "Add-AzApiManagementUserToGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -182,6 +187,7 @@
   {
     "Command": "Backup-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -222,6 +228,7 @@
   {
     "Command": "Export-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -278,6 +285,7 @@
   {
     "Command": "Get-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -306,6 +314,7 @@
   {
     "Command": "Get-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -346,6 +355,7 @@
   {
     "Command": "Get-AzApiManagementApiRelease",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -378,6 +388,7 @@
   {
     "Command": "Get-AzApiManagementApiRevision",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -406,6 +417,7 @@
   {
     "Command": "Get-AzApiManagementApiSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -438,6 +450,7 @@
   {
     "Command": "Get-AzApiManagementApiVersionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -466,6 +479,7 @@
   {
     "Command": "Get-AzApiManagementAuthorizationServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -494,6 +508,7 @@
   {
     "Command": "Get-AzApiManagementAuthorizationServerClientSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -522,6 +537,7 @@
   {
     "Command": "Get-AzApiManagementBackend",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -550,6 +566,7 @@
   {
     "Command": "Get-AzApiManagementCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -578,6 +595,7 @@
   {
     "Command": "Get-AzApiManagementCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -618,6 +636,7 @@
   {
     "Command": "Get-AzApiManagementDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -650,6 +669,7 @@
   {
     "Command": "Get-AzApiManagementGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -674,6 +694,7 @@
   {
     "Command": "Get-AzApiManagementGatewayHostnameConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -702,6 +723,7 @@
   {
     "Command": "Get-AzApiManagementGatewayKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -726,6 +748,7 @@
   {
     "Command": "Get-AzApiManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -762,6 +785,7 @@
   {
     "Command": "Get-AzApiManagementIdentityProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -786,6 +810,7 @@
   {
     "Command": "Get-AzApiManagementIdentityProviderClientSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -810,6 +835,7 @@
   {
     "Command": "Get-AzApiManagementLogger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -834,6 +860,7 @@
   {
     "Command": "Get-AzApiManagementNetworkStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -866,6 +893,7 @@
   {
     "Command": "Get-AzApiManagementOpenIdConnectProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -894,6 +922,7 @@
   {
     "Command": "Get-AzApiManagementOpenIdConnectProviderClientSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -918,6 +947,7 @@
   {
     "Command": "Get-AzApiManagementOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -950,6 +980,7 @@
   {
     "Command": "Get-AzApiManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1010,6 +1041,7 @@
   {
     "Command": "Get-AzApiManagementProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1042,6 +1074,7 @@
   {
     "Command": "Get-AzApiManagementNamedValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1074,6 +1107,7 @@
   {
     "Command": "Get-AzApiManagementNamedValueSecretValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1098,6 +1132,7 @@
   {
     "Command": "Get-AzApiManagementSsoToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1126,6 +1161,7 @@
   {
     "Command": "Get-AzApiManagementSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1162,6 +1198,7 @@
   {
     "Command": "Get-AzApiManagementSubscriptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1186,6 +1223,7 @@
   {
     "Command": "Get-AzApiManagementTenantAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1206,6 +1244,7 @@
   {
     "Command": "Get-AzApiManagementTenantAccessSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1226,6 +1265,7 @@
   {
     "Command": "Get-AzApiManagementTenantGitAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1246,6 +1286,7 @@
   {
     "Command": "Get-AzApiManagementTenantGitAccessSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1266,6 +1307,7 @@
   {
     "Command": "Get-AzApiManagementTenantSyncState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1286,6 +1328,7 @@
   {
     "Command": "Get-AzApiManagementUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1330,6 +1373,7 @@
   {
     "Command": "Get-AzApiManagementUserSsoUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1354,6 +1398,7 @@
   {
     "Command": "Import-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1426,6 +1471,7 @@
   {
     "Command": "New-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1510,6 +1556,7 @@
   {
     "Command": "New-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1606,6 +1653,7 @@
   {
     "Command": "New-AzApiManagementApiRelease",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1654,6 +1702,7 @@
   {
     "Command": "New-AzApiManagementApiRevision",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1706,6 +1755,7 @@
   {
     "Command": "New-AzApiManagementApiSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1758,6 +1808,7 @@
   {
     "Command": "New-AzApiManagementApiVersionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1814,6 +1865,7 @@
   {
     "Command": "New-AzApiManagementAuthorizationServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1902,6 +1954,7 @@
   {
     "Command": "New-AzApiManagementBackend",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -1978,6 +2031,7 @@
   {
     "Command": "New-AzApiManagementBackendCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2014,6 +2068,7 @@
   {
     "Command": "New-AzApiManagementBackendProxy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2038,6 +2093,7 @@
   {
     "Command": "New-AzApiManagementBackendServiceFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2074,6 +2130,7 @@
   {
     "Command": "New-AzApiManagementCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2122,6 +2179,7 @@
   {
     "Command": "New-AzApiManagementCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2158,6 +2216,7 @@
   {
     "Command": "New-AzApiManagementContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2186,6 +2245,7 @@
   {
     "Command": "New-AzApiManagementCustomHostnameConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2234,6 +2294,7 @@
   {
     "Command": "New-AzApiManagementDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2294,6 +2355,7 @@
   {
     "Command": "New-AzApiManagementGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2338,6 +2400,7 @@
   {
     "Command": "New-AzApiManagementGatewayHostnameConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2390,6 +2453,7 @@
   {
     "Command": "New-AzApiManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2430,6 +2494,7 @@
   {
     "Command": "New-AzApiManagementHttpMessageDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2454,6 +2519,7 @@
   {
     "Command": "New-AzApiManagementIdentityProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2526,6 +2592,7 @@
   {
     "Command": "New-AzApiManagementLogger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2570,6 +2637,7 @@
   {
     "Command": "New-AzApiManagementOpenIdConnectProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2614,6 +2682,7 @@
   {
     "Command": "New-AzApiManagementOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2674,6 +2743,7 @@
   {
     "Command": "New-AzApiManagementPipelineDiagnosticSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2698,6 +2768,7 @@
   {
     "Command": "New-AzApiManagementProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2750,6 +2821,7 @@
   {
     "Command": "New-AzApiManagementResourceLocationObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2782,6 +2854,7 @@
   {
     "Command": "New-AzApiManagementNamedValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2834,6 +2907,7 @@
   {
     "Command": "New-AzApiManagementRegion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2862,6 +2936,7 @@
   {
     "Command": "New-AzApiManagementSamplingSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2886,6 +2961,7 @@
   {
     "Command": "New-AzApiManagementSslSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2918,6 +2994,7 @@
   {
     "Command": "New-AzApiManagementSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -2974,6 +3051,7 @@
   {
     "Command": "New-AzApiManagementSystemCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3002,6 +3080,7 @@
   {
     "Command": "New-AzApiManagementUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3050,6 +3129,7 @@
   {
     "Command": "New-AzApiManagementUserToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3082,6 +3162,7 @@
   {
     "Command": "New-AzApiManagementVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3102,6 +3183,7 @@
   {
     "Command": "Publish-AzApiManagementTenantGitConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3150,6 +3232,7 @@
   {
     "Command": "Remove-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3190,6 +3273,7 @@
   {
     "Command": "Remove-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3230,6 +3314,7 @@
   {
     "Command": "Remove-AzApiManagementApiFromGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3274,6 +3359,7 @@
   {
     "Command": "Remove-AzApiManagementApiFromProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3306,6 +3392,7 @@
   {
     "Command": "Remove-AzApiManagementApiRelease",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3354,6 +3441,7 @@
   {
     "Command": "Remove-AzApiManagementApiRevision",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3402,6 +3490,7 @@
   {
     "Command": "Remove-AzApiManagementApiSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3454,6 +3543,7 @@
   {
     "Command": "Remove-AzApiManagementApiVersionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3502,6 +3592,7 @@
   {
     "Command": "Remove-AzApiManagementAuthorizationServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3542,6 +3633,7 @@
   {
     "Command": "Remove-AzApiManagementBackend",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3582,6 +3674,7 @@
   {
     "Command": "Remove-AzApiManagementCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3630,6 +3723,7 @@
   {
     "Command": "Remove-AzApiManagementCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3670,6 +3764,7 @@
   {
     "Command": "Remove-AzApiManagementDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3722,6 +3817,7 @@
   {
     "Command": "Remove-AzApiManagementGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3770,6 +3866,7 @@
   {
     "Command": "Remove-AzApiManagementGatewayHostnameConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3822,6 +3919,7 @@
   {
     "Command": "Remove-AzApiManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3862,6 +3960,7 @@
   {
     "Command": "Remove-AzApiManagementIdentityProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3902,6 +4001,7 @@
   {
     "Command": "Remove-AzApiManagementLogger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3942,6 +4042,7 @@
   {
     "Command": "Remove-AzApiManagementOpenIdConnectProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -3982,6 +4083,7 @@
   {
     "Command": "Remove-AzApiManagementOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4030,6 +4132,7 @@
   {
     "Command": "Remove-AzApiManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4078,6 +4181,7 @@
   {
     "Command": "Remove-AzApiManagementProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4122,6 +4226,7 @@
   {
     "Command": "Remove-AzApiManagementProductFromGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4154,6 +4259,7 @@
   {
     "Command": "Remove-AzApiManagementNamedValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4194,6 +4300,7 @@
   {
     "Command": "Remove-AzApiManagementRegion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4218,6 +4325,7 @@
   {
     "Command": "Remove-AzApiManagementSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4266,6 +4374,7 @@
   {
     "Command": "Remove-AzApiManagementUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4310,6 +4419,7 @@
   {
     "Command": "Remove-AzApiManagementUserFromGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4342,6 +4452,7 @@
   {
     "Command": "Restore-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4382,6 +4493,7 @@
   {
     "Command": "Save-AzApiManagementTenantGitConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4426,6 +4538,7 @@
   {
     "Command": "Set-AzApiManagement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4474,6 +4587,7 @@
   {
     "Command": "Set-AzApiManagementApi",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4554,6 +4668,7 @@
   {
     "Command": "Set-AzApiManagementApiRevision",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4650,6 +4765,7 @@
   {
     "Command": "Set-AzApiManagementApiSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4714,6 +4830,7 @@
   {
     "Command": "Set-AzApiManagementApiVersionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4778,6 +4895,7 @@
   {
     "Command": "Set-AzApiManagementAuthorizationServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4870,6 +4988,7 @@
   {
     "Command": "Set-AzApiManagementBackend",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4954,6 +5073,7 @@
   {
     "Command": "Set-AzApiManagementCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -4994,6 +5114,7 @@
   {
     "Command": "Set-AzApiManagementDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5066,6 +5187,7 @@
   {
     "Command": "Update-AzApiManagementGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5122,6 +5244,7 @@
   {
     "Command": "Set-AzApiManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5170,6 +5293,7 @@
   {
     "Command": "Set-AzApiManagementIdentityProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5250,6 +5374,7 @@
   {
     "Command": "Set-AzApiManagementLogger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5310,6 +5435,7 @@
   {
     "Command": "Set-AzApiManagementOpenIdConnectProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5370,6 +5496,7 @@
   {
     "Command": "Set-AzApiManagementOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5446,6 +5573,7 @@
   {
     "Command": "Set-AzApiManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5502,6 +5630,7 @@
   {
     "Command": "Set-AzApiManagementProduct",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5570,6 +5699,7 @@
   {
     "Command": "Set-AzApiManagementNamedValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5626,6 +5756,7 @@
   {
     "Command": "Set-AzApiManagementSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5702,6 +5833,7 @@
   {
     "Command": "Set-AzApiManagementTenantAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5730,6 +5862,7 @@
   {
     "Command": "Set-AzApiManagementUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5794,6 +5927,7 @@
   {
     "Command": "Update-AzApiManagementApiRelease",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5846,6 +5980,7 @@
   {
     "Command": "Update-AzApiManagementCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [
@@ -5906,6 +6041,7 @@
   {
     "Command": "Update-AzApiManagementRegion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApiManagement",
     "Version": "2.2.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.AppConfiguration.1.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.AppConfiguration.1.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzAppConfigurationStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -57,6 +58,7 @@
   {
     "Command": "Get-AzAppConfigurationStoreKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -120,6 +122,7 @@
   {
     "Command": "New-AzAppConfigurationStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -211,6 +214,7 @@
   {
     "Command": "New-AzAppConfigurationStoreKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -282,6 +286,7 @@
   {
     "Command": "Remove-AzAppConfigurationStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -361,6 +366,7 @@
   {
     "Command": "Test-AzAppConfigurationStoreNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [
@@ -420,6 +426,7 @@
   {
     "Command": "Update-AzAppConfigurationStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.AppConfiguration",
     "Version": "1.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ApplicationInsights.1.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ApplicationInsights.1.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzApplicationInsights",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -41,6 +42,7 @@
   {
     "Command": "New-AzApplicationInsights",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -108,6 +110,7 @@
   {
     "Command": "Remove-AzApplicationInsights",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -159,6 +162,7 @@
   {
     "Command": "Update-AzApplicationInsights",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -216,6 +220,7 @@
   {
     "Command": "Set-AzApplicationInsightsPricingPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -275,6 +280,7 @@
   {
     "Command": "Set-AzApplicationInsightsDailyCap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -330,6 +336,7 @@
   {
     "Command": "Get-AzApplicationInsightsContinuousExport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -369,6 +376,7 @@
   {
     "Command": "Set-AzApplicationInsightsContinuousExport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -440,6 +448,7 @@
   {
     "Command": "New-AzApplicationInsightsContinuousExport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -503,6 +512,7 @@
   {
     "Command": "Remove-AzApplicationInsightsContinuousExport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -558,6 +568,7 @@
   {
     "Command": "Get-AzApplicationInsightsApiKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -597,6 +608,7 @@
   {
     "Command": "New-AzApplicationInsightsApiKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -652,6 +664,7 @@
   {
     "Command": "Remove-AzApplicationInsightsApiKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -707,6 +720,7 @@
   {
     "Command": "Get-AZApplicationInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -739,6 +753,7 @@
   {
     "Command": "New-AZApplicationInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -787,6 +802,7 @@
   {
     "Command": "Update-AZApplicationInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [
@@ -835,6 +851,7 @@
   {
     "Command": "Remove-AZApplicationInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ApplicationInsights",
     "Version": "1.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Automation.1.4.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Automation.1.4.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzAutomationHybridWorkerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -32,6 +33,7 @@
   {
     "Command": "Remove-AzAutomationHybridWorkerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -74,6 +76,7 @@
   {
     "Command": "Get-AzAutomationJobOutputRecord",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -108,6 +111,7 @@
   {
     "Command": "Import-AzAutomationDscNodeConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -160,6 +164,7 @@
   {
     "Command": "Export-AzAutomationDscConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -214,6 +219,7 @@
   {
     "Command": "Export-AzAutomationDscNodeReportContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -268,6 +274,7 @@
   {
     "Command": "Get-AzAutomationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -296,6 +303,7 @@
   {
     "Command": "Get-AzAutomationConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -328,6 +336,7 @@
   {
     "Command": "Get-AzAutomationCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -356,6 +365,7 @@
   {
     "Command": "Get-AzAutomationDscCompilationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -404,6 +414,7 @@
   {
     "Command": "Get-AzAutomationDscCompilationJobOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -442,6 +453,7 @@
   {
     "Command": "Get-AzAutomationDscNodeConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -480,6 +492,7 @@
   {
     "Command": "Get-AzAutomationDscNodeReport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -526,6 +539,7 @@
   {
     "Command": "Get-AzAutomationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -574,6 +588,7 @@
   {
     "Command": "Get-AzAutomationJobOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -612,6 +627,7 @@
   {
     "Command": "Get-AzAutomationModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -640,6 +656,7 @@
   {
     "Command": "Get-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -670,6 +687,7 @@
   {
     "Command": "Export-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -724,6 +742,7 @@
   {
     "Command": "Get-AzAutomationSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -754,6 +773,7 @@
   {
     "Command": "Get-AzAutomationScheduledRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -792,6 +812,7 @@
   {
     "Command": "Get-AzAutomationVariable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -820,6 +841,7 @@
   {
     "Command": "Get-AzAutomationWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -854,6 +876,7 @@
   {
     "Command": "New-AzAutomationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -898,6 +921,7 @@
   {
     "Command": "New-AzAutomationConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -938,6 +962,7 @@
   {
     "Command": "New-AzAutomationCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -974,6 +999,7 @@
   {
     "Command": "New-AzAutomationModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1008,6 +1034,7 @@
   {
     "Command": "New-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1060,6 +1087,7 @@
   {
     "Command": "New-AzAutomationSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1144,6 +1172,7 @@
   {
     "Command": "New-AzAutomationVariable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1184,6 +1213,7 @@
   {
     "Command": "New-AzAutomationWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1250,6 +1280,7 @@
   {
     "Command": "Publish-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1280,6 +1311,7 @@
   {
     "Command": "Register-AzAutomationDscNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1344,6 +1376,7 @@
   {
     "Command": "Register-AzAutomationScheduledRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1388,6 +1421,7 @@
   {
     "Command": "Remove-AzAutomationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1428,6 +1462,7 @@
   {
     "Command": "Remove-AzAutomationConnectionType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1472,6 +1507,7 @@
   {
     "Command": "Remove-AzAutomationConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1516,6 +1552,7 @@
   {
     "Command": "Remove-AzAutomationCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1556,6 +1593,7 @@
   {
     "Command": "Remove-AzAutomationDscNodeConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1606,6 +1644,7 @@
   {
     "Command": "Remove-AzAutomationModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1650,6 +1689,7 @@
   {
     "Command": "Remove-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1696,6 +1736,7 @@
   {
     "Command": "Remove-AzAutomationSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1740,6 +1781,7 @@
   {
     "Command": "Remove-AzAutomationVariable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1780,6 +1822,7 @@
   {
     "Command": "Remove-AzAutomationDscConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1826,6 +1869,7 @@
   {
     "Command": "Remove-AzAutomationWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1866,6 +1910,7 @@
   {
     "Command": "Resume-AzAutomationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1896,6 +1941,7 @@
   {
     "Command": "Set-AzAutomationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1940,6 +1986,7 @@
   {
     "Command": "Set-AzAutomationConnectionFieldValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -1976,6 +2023,7 @@
   {
     "Command": "Set-AzAutomationCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2012,6 +2060,7 @@
   {
     "Command": "Set-AzAutomationModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2050,6 +2099,7 @@
   {
     "Command": "Set-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2096,6 +2146,7 @@
   {
     "Command": "Import-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2174,6 +2225,7 @@
   {
     "Command": "Set-AzAutomationSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2210,6 +2262,7 @@
   {
     "Command": "Set-AzAutomationVariable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2250,6 +2303,7 @@
   {
     "Command": "Set-AzAutomationWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2292,6 +2346,7 @@
   {
     "Command": "Start-AzAutomationDscCompilationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2346,6 +2401,7 @@
   {
     "Command": "Get-AzAutomationRegistrationInfo",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2370,6 +2426,7 @@
   {
     "Command": "Get-AzAutomationDscConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2400,6 +2457,7 @@
   {
     "Command": "Get-AzAutomationDscNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2448,6 +2506,7 @@
   {
     "Command": "Get-AzAutomationDscOnboardingMetaconfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2496,6 +2555,7 @@
   {
     "Command": "Import-AzAutomationDscConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2560,6 +2620,7 @@
   {
     "Command": "New-AzAutomationKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2588,6 +2649,7 @@
   {
     "Command": "Start-AzAutomationRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2638,6 +2700,7 @@
   {
     "Command": "Stop-AzAutomationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2668,6 +2731,7 @@
   {
     "Command": "Suspend-AzAutomationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2698,6 +2762,7 @@
   {
     "Command": "Unregister-AzAutomationDscNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2744,6 +2809,7 @@
   {
     "Command": "Set-AzAutomationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2780,6 +2846,7 @@
   {
     "Command": "Remove-AzAutomationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2822,6 +2889,7 @@
   {
     "Command": "New-AzAutomationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2862,6 +2930,7 @@
   {
     "Command": "Get-AzAutomationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2888,6 +2957,7 @@
   {
     "Command": "Set-AzAutomationDscNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2938,6 +3008,7 @@
   {
     "Command": "Unregister-AzAutomationScheduledRunbook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -2992,6 +3063,7 @@
   {
     "Command": "Start-AzAutomationDscNodeConfigurationDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3050,6 +3122,7 @@
   {
     "Command": "Stop-AzAutomationDscNodeConfigurationDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3102,6 +3175,7 @@
   {
     "Command": "Get-AzAutomationDscNodeConfigurationDeploymentSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3130,6 +3204,7 @@
   {
     "Command": "Get-AzAutomationDscNodeConfigurationDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3170,6 +3245,7 @@
   {
     "Command": "New-AzAutomationSoftwareUpdateConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3286,6 +3362,7 @@
   {
     "Command": "New-AzAutomationUpdateManagementAzureQuery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3328,6 +3405,7 @@
   {
     "Command": "Get-AzAutomationSoftwareUpdateConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3360,6 +3438,7 @@
   {
     "Command": "Remove-AzAutomationSoftwareUpdateConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3408,6 +3487,7 @@
   {
     "Command": "Get-AzAutomationSoftwareUpdateRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3456,6 +3536,7 @@
   {
     "Command": "Get-AzAutomationSoftwareUpdateMachineRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3500,6 +3581,7 @@
   {
     "Command": "New-AzAutomationSourceControl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3572,6 +3654,7 @@
   {
     "Command": "Get-AzAutomationSourceControl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3604,6 +3687,7 @@
   {
     "Command": "Remove-AzAutomationSourceControl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3648,6 +3732,7 @@
   {
     "Command": "Update-AzAutomationSourceControl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3712,6 +3797,7 @@
   {
     "Command": "Start-AzAutomationSourceControlSyncJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3760,6 +3846,7 @@
   {
     "Command": "Get-AzAutomationSourceControlSyncJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3796,6 +3883,7 @@
   {
     "Command": "Get-AzAutomationSourceControlSyncJobOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [
@@ -3842,6 +3930,7 @@
   {
     "Command": "Import-AzAutomationModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Automation",
     "Version": "1.4.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Batch.3.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Batch.3.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Remove-AzBatchAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -44,6 +45,7 @@
   {
     "Command": "Get-AzBatchAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -74,6 +76,7 @@
   {
     "Command": "Get-AzBatchAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -100,6 +103,7 @@
   {
     "Command": "New-AzBatchAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -160,6 +164,7 @@
   {
     "Command": "New-AzBatchAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -190,6 +195,7 @@
   {
     "Command": "Set-AzBatchAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -226,6 +232,7 @@
   {
     "Command": "New-AzBatchApplicationPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -272,6 +279,7 @@
   {
     "Command": "Get-AzBatchJobStatistic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -292,6 +300,7 @@
   {
     "Command": "Remove-AzBatchApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -322,6 +331,7 @@
   {
     "Command": "Remove-AzBatchApplicationPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -356,6 +366,7 @@
   {
     "Command": "Get-AzBatchApplicationPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -390,6 +401,7 @@
   {
     "Command": "Get-AzBatchApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -420,6 +432,7 @@
   {
     "Command": "Set-AzBatchApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -462,6 +475,7 @@
   {
     "Command": "New-AzBatchApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -500,6 +514,7 @@
   {
     "Command": "Get-AzBatchCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -540,6 +555,7 @@
   {
     "Command": "Remove-AzBatchCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -580,6 +596,7 @@
   {
     "Command": "New-AzBatchCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -616,6 +633,7 @@
   {
     "Command": "Stop-AzBatchCertificateDeletion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -644,6 +662,7 @@
   {
     "Command": "Disable-AzBatchComputeNodeScheduling",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -680,6 +699,7 @@
   {
     "Command": "Enable-AzBatchComputeNodeScheduling",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -712,6 +732,7 @@
   {
     "Command": "Get-AzBatchRemoteLoginSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -744,6 +765,7 @@
   {
     "Command": "Remove-AzBatchComputeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -802,6 +824,7 @@
   {
     "Command": "Reset-AzBatchComputeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -838,6 +861,7 @@
   {
     "Command": "Restart-AzBatchComputeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -874,6 +898,7 @@
   {
     "Command": "Set-AzBatchComputeNodeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -914,6 +939,7 @@
   {
     "Command": "Get-AzBatchNodeFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -976,6 +1002,7 @@
   {
     "Command": "Get-AzBatchNodeFileContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1038,6 +1065,7 @@
   {
     "Command": "Get-AzBatchRemoteDesktopProtocolFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1078,6 +1106,7 @@
   {
     "Command": "Remove-AzBatchNodeFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1144,6 +1173,7 @@
   {
     "Command": "Disable-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1168,6 +1198,7 @@
   {
     "Command": "Enable-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1192,6 +1223,7 @@
   {
     "Command": "Set-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1216,6 +1248,7 @@
   {
     "Command": "Stop-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1240,6 +1273,7 @@
   {
     "Command": "Disable-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1268,6 +1302,7 @@
   {
     "Command": "Enable-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1292,6 +1327,7 @@
   {
     "Command": "New-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1366,6 +1402,7 @@
   {
     "Command": "Remove-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1406,6 +1443,7 @@
   {
     "Command": "Set-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1430,6 +1468,7 @@
   {
     "Command": "Stop-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1458,6 +1497,7 @@
   {
     "Command": "Get-AzBatchJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1506,6 +1546,7 @@
   {
     "Command": "Get-AzBatchJobPreparationAndReleaseTaskStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1550,6 +1591,7 @@
   {
     "Command": "Disable-AzBatchAutoScale",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1574,6 +1616,7 @@
   {
     "Command": "Enable-AzBatchAutoScale",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1606,6 +1649,7 @@
   {
     "Command": "Get-AzBatchPoolStatistic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1626,6 +1670,7 @@
   {
     "Command": "Get-AzBatchPoolUsageMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1658,6 +1703,7 @@
   {
     "Command": "Get-AzBatchPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1698,6 +1744,7 @@
   {
     "Command": "Get-AzBatchSupportedImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1726,6 +1773,7 @@
   {
     "Command": "New-AzBatchPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1850,6 +1898,7 @@
   {
     "Command": "Remove-AzBatchPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1890,6 +1939,7 @@
   {
     "Command": "Set-AzBatchPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1914,6 +1964,7 @@
   {
     "Command": "Start-AzBatchPoolResize",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1956,6 +2007,7 @@
   {
     "Command": "Stop-AzBatchPoolResize",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -1980,6 +2032,7 @@
   {
     "Command": "Test-AzBatchAutoScale",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2008,6 +2061,7 @@
   {
     "Command": "Get-AzBatchLocationQuota",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2028,6 +2082,7 @@
   {
     "Command": "Get-AzBatchSubtask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2064,6 +2119,7 @@
   {
     "Command": "Get-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2112,6 +2168,7 @@
   {
     "Command": "New-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2210,6 +2267,7 @@
   {
     "Command": "Remove-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2258,6 +2316,7 @@
   {
     "Command": "New-AzBatchComputeNodeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2306,6 +2365,7 @@
   {
     "Command": "Remove-AzBatchComputeNodeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2350,6 +2410,7 @@
   {
     "Command": "Enable-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2394,6 +2455,7 @@
   {
     "Command": "Set-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2418,6 +2480,7 @@
   {
     "Command": "Stop-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2450,6 +2513,7 @@
   {
     "Command": "Get-AzBatchComputeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2494,6 +2558,7 @@
   {
     "Command": "Get-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2534,6 +2599,7 @@
   {
     "Command": "New-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2574,6 +2640,7 @@
   {
     "Command": "Remove-AzBatchJobSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2614,6 +2681,7 @@
   {
     "Command": "Get-AzBatchTaskCount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2642,6 +2710,7 @@
   {
     "Command": "Get-AzBatchPoolNodeCount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2674,6 +2743,7 @@
   {
     "Command": "Start-AzBatchComputeNodeServiceLogUpload",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2730,6 +2800,7 @@
   {
     "Command": "New-AzBatchResourceFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2770,6 +2841,7 @@
   {
     "Command": "Reactivate-AzBatchTask",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2814,6 +2886,7 @@
   {
     "Command": "Get-AzBatchSubscriptionQuotas",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2834,6 +2907,7 @@
   {
     "Command": "Get-AzBatchAccountKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2860,6 +2934,7 @@
   {
     "Command": "Get-AzBatchJobStatistics",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2880,6 +2955,7 @@
   {
     "Command": "Get-AzBatchLocationQuotas",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2900,6 +2976,7 @@
   {
     "Command": "Get-AzBatchPoolNodeCounts",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2932,6 +3009,7 @@
   {
     "Command": "Get-AzBatchPoolStatistics",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2952,6 +3030,7 @@
   {
     "Command": "Get-AzBatchPoolUsageMetrics",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -2984,6 +3063,7 @@
   {
     "Command": "Get-AzBatchRemoteLoginSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [
@@ -3016,6 +3096,7 @@
   {
     "Command": "Get-AzBatchTaskCounts",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Batch",
     "Version": "3.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Billing.2.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Billing.2.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzBillingInvoice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -50,6 +51,7 @@
   {
     "Command": "Get-AzBillingPeriod",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -74,6 +76,7 @@
   {
     "Command": "Get-AzEnrollmentAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -94,6 +97,7 @@
   {
     "Command": "Get-AzConsumptionBudget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -118,6 +122,7 @@
   {
     "Command": "Get-AzConsumptionMarketplace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -162,6 +167,7 @@
   {
     "Command": "Get-AzConsumptionPriceSheet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -190,6 +196,7 @@
   {
     "Command": "Get-AzConsumptionReservationDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -222,6 +229,7 @@
   {
     "Command": "Get-AzConsumptionReservationSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -258,6 +266,7 @@
   {
     "Command": "Get-AzConsumptionUsageDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -322,6 +331,7 @@
   {
     "Command": "New-AzConsumptionBudget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -414,6 +424,7 @@
   {
     "Command": "Remove-AzConsumptionBudget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -458,6 +469,7 @@
   {
     "Command": "Set-AzConsumptionBudget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -554,6 +566,7 @@
   {
     "Command": "Get-UsageAggregates",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -590,6 +603,7 @@
   {
     "Command": "Get-AzBillingAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -626,6 +640,7 @@
   {
     "Command": "Get-AzBillingProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [
@@ -654,6 +669,7 @@
   {
     "Command": "Get-AzInvoiceSection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Billing",
     "Version": "2.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Cdn.1.6.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Cdn.1.6.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzCdnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -26,6 +27,7 @@
   {
     "Command": "Get-AzCdnProfileSsoUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -54,6 +56,7 @@
   {
     "Command": "New-AzCdnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -102,6 +105,7 @@
   {
     "Command": "Remove-AzCdnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "Set-AzCdnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -182,6 +187,7 @@
   {
     "Command": "Get-AzCdnOrigin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -222,6 +228,7 @@
   {
     "Command": "Set-AzCdnOrigin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -306,6 +313,7 @@
   {
     "Command": "Get-AzCdnEndpointNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -326,6 +334,7 @@
   {
     "Command": "Get-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -358,6 +367,7 @@
   {
     "Command": "Publish-AzCdnEndpointContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -398,6 +408,7 @@
   {
     "Command": "New-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -558,6 +569,7 @@
   {
     "Command": "Unpublish-AzCdnEndpointContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -610,6 +622,7 @@
   {
     "Command": "Remove-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -662,6 +675,7 @@
   {
     "Command": "Set-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -694,6 +708,7 @@
   {
     "Command": "Start-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -742,6 +757,7 @@
   {
     "Command": "Stop-AzCdnEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -790,6 +806,7 @@
   {
     "Command": "Test-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -826,6 +843,7 @@
   {
     "Command": "Get-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -862,6 +880,7 @@
   {
     "Command": "New-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -914,6 +933,7 @@
   {
     "Command": "Remove-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -966,6 +986,7 @@
   {
     "Command": "Enable-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1018,6 +1039,7 @@
   {
     "Command": "Disable-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1070,6 +1092,7 @@
   {
     "Command": "Enable-AzCdnCustomDomainHttps",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1126,6 +1149,7 @@
   {
     "Command": "Disable-AzCdnCustomDomainHttps",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1182,6 +1206,7 @@
   {
     "Command": "Get-AzCdnProfileResourceUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1210,6 +1235,7 @@
   {
     "Command": "Confirm-AzCdnEndpointProbeUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1230,6 +1256,7 @@
   {
     "Command": "Get-AzCdnEndpointResourceUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1262,6 +1289,7 @@
   {
     "Command": "Get-AzCdnProfileSupportedOptimizationType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1290,6 +1318,7 @@
   {
     "Command": "Get-AzCdnSubscriptionResourceUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1306,6 +1335,7 @@
   {
     "Command": "Get-AzCdnEdgeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1322,6 +1352,7 @@
   {
     "Command": "New-AzCdnDeliveryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1354,6 +1385,7 @@
   {
     "Command": "New-AzCdnDeliveryRuleCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1394,6 +1426,7 @@
   {
     "Command": "New-AzCdnDeliveryRuleAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1478,6 +1511,7 @@
   {
     "Command": "New-AzCdnDeliveryPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1502,6 +1536,7 @@
   {
     "Command": "New-AzCdnOrigin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1586,6 +1621,7 @@
   {
     "Command": "Remove-AzCdnOrigin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1642,6 +1678,7 @@
   {
     "Command": "New-AzCdnOriginGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1710,6 +1747,7 @@
   {
     "Command": "Get-AzCdnOriginGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1746,6 +1784,7 @@
   {
     "Command": "Remove-AzCdnOriginGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1802,6 +1841,7 @@
   {
     "Command": "Set-AzCdnOriginGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1870,6 +1910,7 @@
   {
     "Command": "Validate-AzCdnCustomDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [
@@ -1906,6 +1947,7 @@
   {
     "Command": "Get-AzCdnEdgeNodes",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Cdn",
     "Version": "1.6.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.CognitiveServices.1.8.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.CognitiveServices.1.8.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -29,6 +30,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -56,6 +58,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -84,6 +87,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -112,6 +116,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -147,6 +152,7 @@
   {
     "Command": "New-AzCognitiveServicesAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -256,6 +262,7 @@
   {
     "Command": "New-AzCognitiveServicesAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -303,6 +310,7 @@
   {
     "Command": "Remove-AzCognitiveServicesAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -346,6 +354,7 @@
   {
     "Command": "Set-AzCognitiveServicesAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -447,6 +456,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -474,6 +484,7 @@
   {
     "Command": "Update-AzCognitiveServicesAccountNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -525,6 +536,7 @@
   {
     "Command": "Add-AzCognitiveServicesAccountNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -583,6 +595,7 @@
   {
     "Command": "Remove-AzCognitiveServicesAccountNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -641,6 +654,7 @@
   {
     "Command": "New-AzCognitiveServicesAccountApiProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [
@@ -657,6 +671,7 @@
   {
     "Command": "Get-AzCognitiveServicesAccountSkus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.CognitiveServices",
     "Version": "1.8.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Compute.4.7.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Compute.4.7.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Remove-AzAvailabilitySet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -49,6 +50,7 @@
   {
     "Command": "Get-AzAvailabilitySet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -76,6 +78,7 @@
   {
     "Command": "New-AzAvailabilitySet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -131,6 +134,7 @@
   {
     "Command": "Update-AzAvailabilitySet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -181,6 +185,7 @@
   {
     "Command": "Get-AzVMExtensionImageType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -205,6 +210,7 @@
   {
     "Command": "Get-AzVMExtensionImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -241,6 +247,7 @@
   {
     "Command": "Get-AzVMADDomainExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -277,6 +284,7 @@
   {
     "Command": "Set-AzVMADDomainExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -364,6 +372,7 @@
   {
     "Command": "Get-AzVMAEMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -404,6 +413,7 @@
   {
     "Command": "Remove-AzVMAEMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -444,6 +454,7 @@
   {
     "Command": "Set-AzVMAEMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -498,6 +509,7 @@
   {
     "Command": "Test-AzVMAEMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -536,6 +548,7 @@
   {
     "Command": "Set-AzVMBginfoExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -603,6 +616,7 @@
   {
     "Command": "Get-AzVMCustomScriptExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -639,6 +653,7 @@
   {
     "Command": "Remove-AzVMCustomScriptExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -691,6 +706,7 @@
   {
     "Command": "Set-AzVMCustomScriptExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -809,6 +825,7 @@
   {
     "Command": "Get-AzVMDiagnosticsExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -845,6 +862,7 @@
   {
     "Command": "Remove-AzVMDiagnosticsExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -881,6 +899,7 @@
   {
     "Command": "Remove-AzVmssDiagnosticsExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -919,6 +938,7 @@
   {
     "Command": "Set-AzVMDiagnosticsExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -990,6 +1010,7 @@
   {
     "Command": "Set-AzVMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1087,6 +1108,7 @@
   {
     "Command": "Remove-AzVMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1135,6 +1157,7 @@
   {
     "Command": "Get-AzVMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1171,6 +1194,7 @@
   {
     "Command": "Get-AzVMSqlServerExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1199,6 +1223,7 @@
   {
     "Command": "New-AzVMSqlServerAutoBackupConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1271,6 +1296,7 @@
   {
     "Command": "New-AzVMSqlServerAutoPatchingConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1299,6 +1325,7 @@
   {
     "Command": "New-AzVMSqlServerKeyVaultCredentialConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1343,6 +1370,7 @@
   {
     "Command": "Remove-AzVMSqlServerExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1379,6 +1407,7 @@
   {
     "Command": "Set-AzVMSqlServerExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1429,6 +1458,7 @@
   {
     "Command": "Get-AzVMImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1473,6 +1503,7 @@
   {
     "Command": "Get-AzVMAccessExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1509,6 +1540,7 @@
   {
     "Command": "Remove-AzVMAccessExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1561,6 +1593,7 @@
   {
     "Command": "Set-AzVMAccessExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1632,6 +1665,7 @@
   {
     "Command": "Get-AzVMImageSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1660,6 +1694,7 @@
   {
     "Command": "Get-AzVMImagePublisher",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1680,6 +1715,7 @@
   {
     "Command": "Get-AzVMImageOffer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1704,6 +1740,7 @@
   {
     "Command": "Get-AzRemoteDesktopFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1739,6 +1776,7 @@
   {
     "Command": "Get-AzVMUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1759,6 +1797,7 @@
   {
     "Command": "Get-AzVMSize",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1791,6 +1830,7 @@
   {
     "Command": "Save-AzVMImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1843,6 +1883,7 @@
   {
     "Command": "Set-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1895,6 +1936,7 @@
   {
     "Command": "Add-AzVMAdditionalUnattendContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1925,6 +1967,7 @@
   {
     "Command": "Add-AzVMSshPublicKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1955,6 +1998,7 @@
   {
     "Command": "Add-AzVMSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -1991,6 +2035,7 @@
   {
     "Command": "Remove-AzVMSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2031,6 +2076,7 @@
   {
     "Command": "Remove-AzVMNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2072,6 +2118,7 @@
   {
     "Command": "Remove-AzVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2112,6 +2159,7 @@
   {
     "Command": "Set-AzVMBootDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2150,6 +2198,7 @@
   {
     "Command": "Set-AzVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2200,6 +2249,7 @@
   {
     "Command": "Set-AzVMPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2238,6 +2288,7 @@
   {
     "Command": "Set-AzVMSourceImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2280,6 +2331,7 @@
   {
     "Command": "Set-AzVMOSDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2378,6 +2430,7 @@
   {
     "Command": "Get-AzVMBootDiagnosticsData",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2417,6 +2470,7 @@
   {
     "Command": "Get-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2460,6 +2514,7 @@
   {
     "Command": "Update-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2546,6 +2601,7 @@
   {
     "Command": "Restart-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2598,6 +2654,7 @@
   {
     "Command": "New-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2776,6 +2833,7 @@
   {
     "Command": "Start-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2824,6 +2882,7 @@
   {
     "Command": "Stop-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2884,6 +2943,7 @@
   {
     "Command": "Remove-AzVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -2939,6 +2999,7 @@
   {
     "Command": "New-AzVMConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3024,6 +3085,7 @@
   {
     "Command": "Set-AzVMOperatingSystem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3102,6 +3164,7 @@
   {
     "Command": "Add-AzVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3170,6 +3233,7 @@
   {
     "Command": "Add-AzVMNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3207,6 +3271,7 @@
   {
     "Command": "Add-AzVhd",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3261,6 +3326,7 @@
   {
     "Command": "Save-AzVhd",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3316,6 +3382,7 @@
   {
     "Command": "Add-AzContainerServiceAgentPoolProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3364,6 +3431,7 @@
   {
     "Command": "New-AzContainerServiceConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3448,6 +3516,7 @@
   {
     "Command": "Remove-AzContainerServiceAgentPoolProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3484,6 +3553,7 @@
   {
     "Command": "New-AzContainerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3528,6 +3598,7 @@
   {
     "Command": "Update-AzContainerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3572,6 +3643,7 @@
   {
     "Command": "Remove-AzContainerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3616,6 +3688,7 @@
   {
     "Command": "Get-AzContainerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3640,6 +3713,7 @@
   {
     "Command": "Get-AzVmssVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3674,6 +3748,7 @@
   {
     "Command": "Set-AzVmssVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3740,6 +3815,7 @@
   {
     "Command": "Add-AzVmssAdditionalUnattendContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3788,6 +3864,7 @@
   {
     "Command": "Add-AzVmssExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3856,6 +3933,7 @@
   {
     "Command": "Add-AzVmssDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3928,6 +4006,7 @@
   {
     "Command": "Add-AzVmssNetworkInterfaceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -3994,6 +4073,7 @@
   {
     "Command": "Add-AzVmssSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4034,6 +4114,7 @@
   {
     "Command": "Add-AzVmssSshPublicKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4074,6 +4155,7 @@
   {
     "Command": "Add-AzVmssWinRMListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4114,6 +4196,7 @@
   {
     "Command": "New-AzVmssConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4300,6 +4383,7 @@
   {
     "Command": "New-AzVmssIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4390,6 +4474,7 @@
   {
     "Command": "New-AzVmssVaultCertificateConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4426,6 +4511,7 @@
   {
     "Command": "Remove-AzVmssExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4466,6 +4552,7 @@
   {
     "Command": "Remove-AzVmssDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4506,6 +4593,7 @@
   {
     "Command": "Remove-AzVmssNetworkInterfaceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4546,6 +4634,7 @@
   {
     "Command": "Set-AzVmssOsProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4626,6 +4715,7 @@
   {
     "Command": "Set-AzVmssStorageProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4724,6 +4814,7 @@
   {
     "Command": "New-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -4910,6 +5001,7 @@
   {
     "Command": "Update-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5144,6 +5236,7 @@
   {
     "Command": "Stop-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5202,6 +5295,7 @@
   {
     "Command": "Remove-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5252,6 +5346,7 @@
   {
     "Command": "Get-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5286,6 +5381,7 @@
   {
     "Command": "Get-AzVmssSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5312,6 +5408,7 @@
   {
     "Command": "Set-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5378,6 +5475,7 @@
   {
     "Command": "Restart-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5424,6 +5522,7 @@
   {
     "Command": "Start-AzVmss",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5470,6 +5569,7 @@
   {
     "Command": "Update-AzVmssInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5516,6 +5616,7 @@
   {
     "Command": "Get-AzVMDscExtensionStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5544,6 +5645,7 @@
   {
     "Command": "Publish-AzVMDscConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5614,6 +5716,7 @@
   {
     "Command": "Remove-AzVMDscExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5658,6 +5761,7 @@
   {
     "Command": "Set-AzVMDscExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5768,6 +5872,7 @@
   {
     "Command": "Get-AzVMDscExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5800,6 +5905,7 @@
   {
     "Command": "Add-AzVmssDiagnosticsExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5861,6 +5967,7 @@
   {
     "Command": "Get-AzVMChefExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5905,6 +6012,7 @@
   {
     "Command": "Remove-AzVMChefExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -5961,6 +6069,7 @@
   {
     "Command": "Set-AzVMChefExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6086,6 +6195,7 @@
   {
     "Command": "Remove-AzVMBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6116,6 +6226,7 @@
   {
     "Command": "Disable-AzVMDiskEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6187,6 +6298,7 @@
   {
     "Command": "Get-AzVMDiskEncryptionStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6227,6 +6339,7 @@
   {
     "Command": "Remove-AzVMDiskEncryptionExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6279,6 +6392,7 @@
   {
     "Command": "Set-AzVMDiskEncryptionExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6398,6 +6512,7 @@
   {
     "Command": "Set-AzVMBackupExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6434,6 +6549,7 @@
   {
     "Command": "New-AzDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6480,6 +6596,7 @@
   {
     "Command": "Update-AzDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6530,6 +6647,7 @@
   {
     "Command": "Get-AzDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6556,6 +6674,7 @@
   {
     "Command": "Remove-AzDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6602,6 +6721,7 @@
   {
     "Command": "Grant-AzDiskAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6652,6 +6772,7 @@
   {
     "Command": "Revoke-AzDiskAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6694,6 +6815,7 @@
   {
     "Command": "New-AzDiskConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6836,6 +6958,7 @@
   {
     "Command": "Set-AzDiskDiskEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6876,6 +6999,7 @@
   {
     "Command": "Set-AzDiskImageReference",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6916,6 +7040,7 @@
   {
     "Command": "Set-AzDiskKeyEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -6956,6 +7081,7 @@
   {
     "Command": "New-AzDiskUpdateConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7054,6 +7180,7 @@
   {
     "Command": "Set-AzDiskUpdateDiskEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7094,6 +7221,7 @@
   {
     "Command": "Set-AzDiskUpdateKeyEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7134,6 +7262,7 @@
   {
     "Command": "New-AzSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7180,6 +7309,7 @@
   {
     "Command": "Update-AzSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7230,6 +7360,7 @@
   {
     "Command": "Get-AzSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7256,6 +7387,7 @@
   {
     "Command": "Remove-AzSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7302,6 +7434,7 @@
   {
     "Command": "Grant-AzSnapshotAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7352,6 +7485,7 @@
   {
     "Command": "Revoke-AzSnapshotAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7394,6 +7528,7 @@
   {
     "Command": "New-AzSnapshotConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7500,6 +7635,7 @@
   {
     "Command": "Set-AzSnapshotDiskEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7540,6 +7676,7 @@
   {
     "Command": "Set-AzSnapshotImageReference",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7580,6 +7717,7 @@
   {
     "Command": "Set-AzSnapshotKeyEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7620,6 +7758,7 @@
   {
     "Command": "New-AzSnapshotUpdateConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7686,6 +7825,7 @@
   {
     "Command": "Set-AzSnapshotUpdateDiskEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7726,6 +7866,7 @@
   {
     "Command": "Set-AzSnapshotUpdateKeyEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7766,6 +7907,7 @@
   {
     "Command": "New-AzImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7812,6 +7954,7 @@
   {
     "Command": "Update-AzImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7866,6 +8009,7 @@
   {
     "Command": "Get-AzImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7896,6 +8040,7 @@
   {
     "Command": "Remove-AzImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7942,6 +8087,7 @@
   {
     "Command": "New-AzImageConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -7998,6 +8144,7 @@
   {
     "Command": "Set-AzImageOsDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8066,6 +8213,7 @@
   {
     "Command": "Add-AzImageDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8130,6 +8278,7 @@
   {
     "Command": "Remove-AzImageDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8166,6 +8315,7 @@
   {
     "Command": "ConvertTo-AzVMManagedDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8208,6 +8358,7 @@
   {
     "Command": "Set-AzVmssBootDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8248,6 +8399,7 @@
   {
     "Command": "Get-AzComputeResourceSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8268,6 +8420,7 @@
   {
     "Command": "Get-AzVMRunCommandDocument",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8292,6 +8445,7 @@
   {
     "Command": "Invoke-AzVMRunCommand",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8356,6 +8510,7 @@
   {
     "Command": "Start-AzVmssRollingOSUpgrade",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8398,6 +8553,7 @@
   {
     "Command": "Stop-AzVmssRollingUpgrade",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8444,6 +8600,7 @@
   {
     "Command": "Get-AzVmssRollingUpgrade",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8470,6 +8627,7 @@
   {
     "Command": "Set-AzVmssRollingUpgradePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8518,6 +8676,7 @@
   {
     "Command": "Set-AzVmssDiskEncryptionExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8607,6 +8766,7 @@
   {
     "Command": "Disable-AzVmssDiskEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8665,6 +8825,7 @@
   {
     "Command": "Get-AzVmssDiskEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8695,6 +8856,7 @@
   {
     "Command": "Get-AzVmssVMDiskEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8729,6 +8891,7 @@
   {
     "Command": "Export-AzLogAnalyticRequestRateByInterval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8797,6 +8960,7 @@
   {
     "Command": "Export-AzLogAnalyticThrottledRequest",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8861,6 +9025,7 @@
   {
     "Command": "Repair-AzVmssServiceFabricUpdateDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8915,6 +9080,7 @@
   {
     "Command": "New-AzVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -8977,6 +9143,7 @@
   {
     "Command": "Update-AzVmssVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9043,6 +9210,7 @@
   {
     "Command": "New-AzVmssIpTagConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9079,6 +9247,7 @@
   {
     "Command": "Invoke-AzVmssVMRunCommand",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9145,6 +9314,7 @@
   {
     "Command": "New-AzGallery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9199,6 +9369,7 @@
   {
     "Command": "Update-AzGallery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9259,6 +9430,7 @@
   {
     "Command": "Get-AzGallery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9289,6 +9461,7 @@
   {
     "Command": "Remove-AzGallery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9345,6 +9518,7 @@
   {
     "Command": "New-AzGalleryImageDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9475,6 +9649,7 @@
   {
     "Command": "Update-AzGalleryImageDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9587,6 +9762,7 @@
   {
     "Command": "Get-AzGalleryImageDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9621,6 +9797,7 @@
   {
     "Command": "Remove-AzGalleryImageDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9681,6 +9858,7 @@
   {
     "Command": "New-AzGalleryImageVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9771,6 +9949,7 @@
   {
     "Command": "Update-AzGalleryImageVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9851,6 +10030,7 @@
   {
     "Command": "Get-AzGalleryImageVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9893,6 +10073,7 @@
   {
     "Command": "Remove-AzGalleryImageVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -9957,6 +10138,7 @@
   {
     "Command": "Add-AzVmssVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10009,6 +10191,7 @@
   {
     "Command": "Remove-AzVmssVMDataDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10033,6 +10216,7 @@
   {
     "Command": "Invoke-AzVMReimage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10079,6 +10263,7 @@
   {
     "Command": "New-AzProximityPlacementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10133,6 +10318,7 @@
   {
     "Command": "Get-AzProximityPlacementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10167,6 +10353,7 @@
   {
     "Command": "Remove-AzProximityPlacementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10223,6 +10410,7 @@
   {
     "Command": "New-AzHostGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10285,6 +10473,7 @@
   {
     "Command": "Get-AzHostGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10319,6 +10508,7 @@
   {
     "Command": "Remove-AzHostGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10371,6 +10561,7 @@
   {
     "Command": "New-AzHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10441,6 +10632,7 @@
   {
     "Command": "Get-AzHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10479,6 +10671,7 @@
   {
     "Command": "Remove-AzHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10535,6 +10728,7 @@
   {
     "Command": "New-AzDiskEncryptionSetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10587,6 +10781,7 @@
   {
     "Command": "New-AzDiskEncryptionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10635,6 +10830,7 @@
   {
     "Command": "Get-AzDiskEncryptionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10661,6 +10857,7 @@
   {
     "Command": "Remove-AzDiskEncryptionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10717,6 +10914,7 @@
   {
     "Command": "Update-AzDiskEncryptionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10781,6 +10979,7 @@
   {
     "Command": "Set-AzVmssOrchestrationServiceState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10839,6 +11038,7 @@
   {
     "Command": "New-AzDiskAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10885,6 +11085,7 @@
   {
     "Command": "Remove-AzDiskAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10937,6 +11138,7 @@
   {
     "Command": "Get-AzDiskAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -10967,6 +11169,7 @@
   {
     "Command": "Invoke-AzVmPatchAssessment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11017,6 +11220,7 @@
   {
     "Command": "Get-AzDiskEncryptionSetAssociatedResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11043,6 +11247,7 @@
   {
     "Command": "Start-AzVmssRollingExtensionUpgrade",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11093,6 +11298,7 @@
   {
     "Command": "Get-AzVmssDiskEncryptionStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11123,6 +11329,7 @@
   {
     "Command": "Get-AzVmssVMDiskEncryptionStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11157,6 +11364,7 @@
   {
     "Command": "Repair-AzVmssServiceFabricUD",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11211,6 +11419,7 @@
   {
     "Command": "Invoke-AzVmAssessPatch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [
@@ -11261,6 +11470,7 @@
   {
     "Command": "Invoke-AzVmPatchAssess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Compute",
     "Version": "4.7.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ContainerInstance.1.0.3.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ContainerInstance.1.0.3.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzContainerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerInstance",
     "Version": "1.0.3",
     "Parameters": [
@@ -122,6 +123,7 @@
   {
     "Command": "Get-AzContainerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerInstance",
     "Version": "1.0.3",
     "Parameters": [
@@ -150,6 +152,7 @@
   {
     "Command": "Remove-AzContainerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerInstance",
     "Version": "1.0.3",
     "Parameters": [
@@ -198,6 +201,7 @@
   {
     "Command": "Get-AzContainerInstanceLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerInstance",
     "Version": "1.0.3",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ContainerRegistry.2.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ContainerRegistry.2.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzContainerRegistry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -65,6 +66,7 @@
   {
     "Command": "Get-AzContainerRegistry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -103,6 +105,7 @@
   {
     "Command": "Update-AzContainerRegistry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -182,6 +185,7 @@
   {
     "Command": "Remove-AzContainerRegistry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -236,6 +240,7 @@
   {
     "Command": "Get-AzContainerRegistryCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -274,6 +279,7 @@
   {
     "Command": "Update-AzContainerRegistryCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -328,6 +334,7 @@
   {
     "Command": "Test-AzContainerRegistryNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -352,6 +359,7 @@
   {
     "Command": "Get-AzContainerRegistryReplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -395,6 +403,7 @@
   {
     "Command": "New-AzContainerRegistryReplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -462,6 +471,7 @@
   {
     "Command": "Remove-AzContainerRegistryReplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -523,6 +533,7 @@
   {
     "Command": "New-AzContainerRegistryWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -620,6 +631,7 @@
   {
     "Command": "Get-AzContainerRegistryWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -667,6 +679,7 @@
   {
     "Command": "Update-AzContainerRegistryWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -758,6 +771,7 @@
   {
     "Command": "Test-AzContainerRegistryWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -801,6 +815,7 @@
   {
     "Command": "Remove-AzContainerRegistryWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -860,6 +875,7 @@
   {
     "Command": "Get-AzContainerRegistryWebhookEvent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -900,6 +916,7 @@
   {
     "Command": "Import-AzContainerRegistryImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -968,6 +985,7 @@
   {
     "Command": "Get-AzContainerRegistryUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -994,6 +1012,7 @@
   {
     "Command": "Set-AzContainerRegistryNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -1022,6 +1041,7 @@
   {
     "Command": "New-AzContainerRegistryNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [
@@ -1058,6 +1078,7 @@
   {
     "Command": "Connect-AzContainerRegistry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ContainerRegistry",
     "Version": "2.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataBoxEdge.1.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataBoxEdge.1.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDataBoxEdgeJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -38,6 +39,7 @@
   {
     "Command": "Get-AzDataBoxEdgeDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -82,6 +84,7 @@
   {
     "Command": "Invoke-AzDataBoxEdgeDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -146,6 +149,7 @@
   {
     "Command": "New-AzDataBoxEdgeDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -194,6 +198,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -246,6 +251,7 @@
   {
     "Command": "Get-AzDataBoxEdgeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -282,6 +288,7 @@
   {
     "Command": "New-AzDataBoxEdgeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -338,6 +345,7 @@
   {
     "Command": "Set-AzDataBoxEdgeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -398,6 +406,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -454,6 +463,7 @@
   {
     "Command": "Get-AzDataBoxEdgeStorageAccountCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -490,6 +500,7 @@
   {
     "Command": "New-AzDataBoxEdgeStorageAccountCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -546,6 +557,7 @@
   {
     "Command": "Set-AzDataBoxEdgeStorageAccountCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -610,6 +622,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeStorageAccountCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -666,6 +679,7 @@
   {
     "Command": "Get-AzDataBoxEdgeShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -702,6 +716,7 @@
   {
     "Command": "New-AzDataBoxEdgeShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -778,6 +793,7 @@
   {
     "Command": "Set-AzDataBoxEdgeShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -838,6 +854,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -894,6 +911,7 @@
   {
     "Command": "Invoke-AzDataBoxEdgeShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -958,6 +976,7 @@
   {
     "Command": "Get-AzDataBoxEdgeBandwidthSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -994,6 +1013,7 @@
   {
     "Command": "Set-AzDataBoxEdgeBandwidthSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1066,6 +1086,7 @@
   {
     "Command": "New-AzDataBoxEdgeBandwidthSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1130,6 +1151,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeBandwidthSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1186,6 +1208,7 @@
   {
     "Command": "Get-AzDataBoxEdgeRole",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1222,6 +1245,7 @@
   {
     "Command": "Set-AzDataBoxEdgeRole",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1276,6 +1300,7 @@
   {
     "Command": "New-AzDataBoxEdgeRole",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1368,6 +1393,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeRole",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1424,6 +1450,7 @@
   {
     "Command": "Get-AzDataBoxEdgeTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1460,6 +1487,7 @@
   {
     "Command": "New-AzDataBoxEdgeTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1536,6 +1564,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1592,6 +1621,7 @@
   {
     "Command": "Get-AzDataBoxEdgeOrder",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1624,6 +1654,7 @@
   {
     "Command": "New-AzDataBoxEdgeOrder",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1708,6 +1739,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeOrder",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1762,6 +1794,7 @@
   {
     "Command": "Get-AzDataBoxEdgeStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1800,6 +1833,7 @@
   {
     "Command": "New-AzDataBoxEdgeStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1852,6 +1886,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1908,6 +1943,7 @@
   {
     "Command": "Get-AzDataBoxEdgeStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -1950,6 +1986,7 @@
   {
     "Command": "New-AzDataBoxEdgeStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -2002,6 +2039,7 @@
   {
     "Command": "Remove-AzDataBoxEdgeStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [
@@ -2062,6 +2100,7 @@
   {
     "Command": "Invoke-AzDataBoxEdgeStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataBoxEdge",
     "Version": "1.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataFactory.1.11.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataFactory.1.11.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Set-AzDataFactoryV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -99,6 +100,7 @@
   {
     "Command": "Update-AzDataFactoryV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -149,6 +151,7 @@
   {
     "Command": "Get-AzDataFactoryV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -175,6 +178,7 @@
   {
     "Command": "Remove-AzDataFactoryV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -225,6 +229,7 @@
   {
     "Command": "Set-AzDataFactoryV2LinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -281,6 +286,7 @@
   {
     "Command": "New-AzDataFactoryV2LinkedServiceEncryptedCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -335,6 +341,7 @@
   {
     "Command": "Get-AzDataFactoryV2LinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -373,6 +380,7 @@
   {
     "Command": "Remove-AzDataFactoryV2LinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -427,6 +435,7 @@
   {
     "Command": "Set-AzDataFactoryV2DataFlow",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -483,6 +492,7 @@
   {
     "Command": "Get-AzDataFactoryV2DataFlow",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -521,6 +531,7 @@
   {
     "Command": "Remove-AzDataFactoryV2DataFlow",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -579,6 +590,7 @@
   {
     "Command": "Start-AzDataFactoryV2DataFlowDebugSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -633,6 +645,7 @@
   {
     "Command": "Add-AzDataFactoryV2DataFlowDebugSessionPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -691,6 +704,7 @@
   {
     "Command": "Invoke-AzDataFactoryV2DataFlowDebugSessionCommand",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -763,6 +777,7 @@
   {
     "Command": "Stop-AzDataFactoryV2DataFlowDebugSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -819,6 +834,7 @@
   {
     "Command": "Get-AzDataFactoryV2DataFlowDebugSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -851,6 +867,7 @@
   {
     "Command": "Set-AzDataFactoryV2Dataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -907,6 +924,7 @@
   {
     "Command": "Get-AzDataFactoryV2Dataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -945,6 +963,7 @@
   {
     "Command": "Remove-AzDataFactoryV2Dataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -999,6 +1018,7 @@
   {
     "Command": "Set-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1055,6 +1075,7 @@
   {
     "Command": "Get-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1093,6 +1114,7 @@
   {
     "Command": "Remove-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1147,6 +1169,7 @@
   {
     "Command": "Start-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1201,6 +1224,7 @@
   {
     "Command": "Stop-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1255,6 +1279,7 @@
   {
     "Command": "Set-AzDataFactoryV2Pipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1311,6 +1336,7 @@
   {
     "Command": "Get-AzDataFactoryV2Pipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1349,6 +1375,7 @@
   {
     "Command": "Remove-AzDataFactoryV2Pipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1403,6 +1430,7 @@
   {
     "Command": "Invoke-AzDataFactoryV2Pipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1471,6 +1499,7 @@
   {
     "Command": "Get-AzDataFactoryV2PipelineRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1515,6 +1544,7 @@
   {
     "Command": "Stop-AzDataFactoryV2PipelineRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1567,6 +1597,7 @@
   {
     "Command": "Get-AzDataFactoryV2ActivityRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1615,6 +1646,7 @@
   {
     "Command": "Get-AzDataFactoryV2IntegrationRuntimeKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1655,6 +1687,7 @@
   {
     "Command": "Get-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1699,6 +1732,7 @@
   {
     "Command": "New-AzDataFactoryV2IntegrationRuntimeKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1759,6 +1793,7 @@
   {
     "Command": "Remove-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1819,6 +1854,7 @@
   {
     "Command": "Set-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -1973,6 +2009,7 @@
   {
     "Command": "Start-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2029,6 +2066,7 @@
   {
     "Command": "Stop-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2085,6 +2123,7 @@
   {
     "Command": "Get-AzDataFactoryV2IntegrationRuntimeMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2125,6 +2164,7 @@
   {
     "Command": "Remove-AzDataFactoryV2IntegrationRuntimeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2183,6 +2223,7 @@
   {
     "Command": "Update-AzDataFactoryV2IntegrationRuntimeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2241,6 +2282,7 @@
   {
     "Command": "Get-AzDataFactoryV2IntegrationRuntimeNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2287,6 +2329,7 @@
   {
     "Command": "Invoke-AzDataFactoryV2IntegrationRuntimeUpgrade",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2339,6 +2382,7 @@
   {
     "Command": "Sync-AzDataFactoryV2IntegrationRuntimeCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2393,6 +2437,7 @@
   {
     "Command": "Update-AzDataFactoryV2IntegrationRuntime",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2453,6 +2498,7 @@
   {
     "Command": "Get-AzDataFactoryV2TriggerRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2495,6 +2541,7 @@
   {
     "Command": "Remove-AzDataFactory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2541,6 +2588,7 @@
   {
     "Command": "Get-AzDataFactoryRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2577,6 +2625,7 @@
   {
     "Command": "Get-AzDataFactorySlice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2617,6 +2666,7 @@
   {
     "Command": "Save-AzDataFactoryLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2657,6 +2707,7 @@
   {
     "Command": "Set-AzDataFactorySliceStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2705,6 +2756,7 @@
   {
     "Command": "New-AzDataFactoryEncryptValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2765,6 +2817,7 @@
   {
     "Command": "Get-AzDataFactoryGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2797,6 +2850,7 @@
   {
     "Command": "New-AzDataFactoryGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2833,6 +2887,7 @@
   {
     "Command": "Get-AzDataFactoryGatewayAuthkey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2867,6 +2922,7 @@
   {
     "Command": "New-AzDataFactoryGatewayAuthkey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2917,6 +2973,7 @@
   {
     "Command": "Remove-AzDataFactoryGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -2965,6 +3022,7 @@
   {
     "Command": "Set-AzDataFactoryGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3001,6 +3059,7 @@
   {
     "Command": "Get-AzDataFactoryHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3033,6 +3092,7 @@
   {
     "Command": "New-AzDataFactoryHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3085,6 +3145,7 @@
   {
     "Command": "Remove-AzDataFactoryHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3135,6 +3196,7 @@
   {
     "Command": "Get-AzDataFactoryLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3167,6 +3229,7 @@
   {
     "Command": "Get-AzDataFactoryActivityWindow",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3243,6 +3306,7 @@
   {
     "Command": "New-AzDataFactoryLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3295,6 +3359,7 @@
   {
     "Command": "Remove-AzDataFactoryLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3345,6 +3410,7 @@
   {
     "Command": "Get-AzDataFactory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3369,6 +3435,7 @@
   {
     "Command": "New-AzDataFactory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3417,6 +3484,7 @@
   {
     "Command": "Get-AzDataFactoryPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3449,6 +3517,7 @@
   {
     "Command": "New-AzDataFactoryPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3501,6 +3570,7 @@
   {
     "Command": "Remove-AzDataFactoryPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3551,6 +3621,7 @@
   {
     "Command": "Resume-AzDataFactoryPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3597,6 +3668,7 @@
   {
     "Command": "Set-AzDataFactoryPipelineActivePeriod",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3659,6 +3731,7 @@
   {
     "Command": "Suspend-AzDataFactoryPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3705,6 +3778,7 @@
   {
     "Command": "Get-AzDataFactoryDataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3737,6 +3811,7 @@
   {
     "Command": "New-AzDataFactoryDataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3789,6 +3864,7 @@
   {
     "Command": "Remove-AzDataFactoryDataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3839,6 +3915,7 @@
   {
     "Command": "Add-AzDataFactoryV2TriggerSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3889,6 +3966,7 @@
   {
     "Command": "Remove-AzDataFactoryV2TriggerSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3947,6 +4025,7 @@
   {
     "Command": "Get-AzDataFactoryV2TriggerSubscriptionStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -3985,6 +4064,7 @@
   {
     "Command": "Stop-AzDataFactoryV2TriggerRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4041,6 +4121,7 @@
   {
     "Command": "Invoke-AzDataFactoryV2TriggerRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4097,6 +4178,7 @@
   {
     "Command": "New-AzDataFactoryV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4194,6 +4276,7 @@
   {
     "Command": "New-AzDataFactoryV2Dataset",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4250,6 +4333,7 @@
   {
     "Command": "New-AzDataFactoryV2LinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4306,6 +4390,7 @@
   {
     "Command": "New-AzDataFactoryV2Pipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [
@@ -4362,6 +4447,7 @@
   {
     "Command": "New-AzDataFactoryV2Trigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataFactory",
     "Version": "1.11.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataLakeAnalytics.1.0.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataLakeAnalytics.1.0.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -38,6 +39,7 @@
   {
     "Command": "New-AzDataLakeAnalyticsCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -96,6 +98,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -154,6 +157,7 @@
   {
     "Command": "Set-AzDataLakeAnalyticsCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -216,6 +220,7 @@
   {
     "Command": "Test-AzDataLakeAnalyticsCatalogItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -246,6 +251,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsCatalogItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -276,6 +282,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -314,6 +321,7 @@
   {
     "Command": "Set-AzDataLakeAnalyticsCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -387,6 +395,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -448,6 +457,7 @@
   {
     "Command": "Set-AzDataLakeAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -484,6 +494,7 @@
   {
     "Command": "Wait-AzDataLakeAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -518,6 +529,7 @@
   {
     "Command": "Test-AzDataLakeAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -542,6 +554,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -598,6 +611,7 @@
   {
     "Command": "Add-AzDataLakeAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -638,6 +652,7 @@
   {
     "Command": "Stop-AzDataLakeAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -684,6 +699,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -750,6 +766,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -774,6 +791,7 @@
   {
     "Command": "Submit-AzDataLakeAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -858,6 +876,7 @@
   {
     "Command": "New-AzDataLakeAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -912,6 +931,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -956,6 +976,7 @@
   {
     "Command": "Set-AzDataLakeAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1010,6 +1031,7 @@
   {
     "Command": "Add-AzDataLakeAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1060,6 +1082,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1090,6 +1113,7 @@
   {
     "Command": "Set-AzDataLakeAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1140,6 +1164,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1186,6 +1211,7 @@
   {
     "Command": "New-AzDataLakeAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1248,6 +1274,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1280,6 +1307,7 @@
   {
     "Command": "Update-AzDataLakeAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1334,6 +1362,7 @@
   {
     "Command": "Remove-AzDataLakeAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1382,6 +1411,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsJobPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1418,6 +1448,7 @@
   {
     "Command": "Get-AzDataLakeAnalyticsJobRecurrence",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1454,6 +1485,7 @@
   {
     "Command": "Get-AdlAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1490,6 +1522,7 @@
   {
     "Command": "New-AdlCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1548,6 +1581,7 @@
   {
     "Command": "Remove-AdlCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1606,6 +1640,7 @@
   {
     "Command": "Set-AdlCatalogCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1668,6 +1703,7 @@
   {
     "Command": "Test-AdlCatalogItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1698,6 +1734,7 @@
   {
     "Command": "Get-AdlCatalogItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1728,6 +1765,7 @@
   {
     "Command": "Get-AdlCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1766,6 +1804,7 @@
   {
     "Command": "Set-AdlCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1839,6 +1878,7 @@
   {
     "Command": "Remove-AdlCatalogItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1900,6 +1940,7 @@
   {
     "Command": "Set-AdlAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1936,6 +1977,7 @@
   {
     "Command": "Wait-AdlJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1970,6 +2012,7 @@
   {
     "Command": "Test-AdlAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -1994,6 +2037,7 @@
   {
     "Command": "Remove-AdlAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2050,6 +2094,7 @@
   {
     "Command": "Add-AdlAnalyticsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2090,6 +2135,7 @@
   {
     "Command": "Stop-AdlJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2136,6 +2182,7 @@
   {
     "Command": "Get-AdlJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2202,6 +2249,7 @@
   {
     "Command": "Get-AdlAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2226,6 +2274,7 @@
   {
     "Command": "Submit-AdlJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2310,6 +2359,7 @@
   {
     "Command": "New-AdlAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2364,6 +2414,7 @@
   {
     "Command": "Remove-AdlAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2408,6 +2459,7 @@
   {
     "Command": "Set-AdlAnalyticsAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2462,6 +2514,7 @@
   {
     "Command": "Add-AdlAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2512,6 +2565,7 @@
   {
     "Command": "Get-AdlAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2542,6 +2596,7 @@
   {
     "Command": "Set-AdlAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2592,6 +2647,7 @@
   {
     "Command": "Remove-AdlAnalyticsFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2638,6 +2694,7 @@
   {
     "Command": "New-AdlAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2700,6 +2757,7 @@
   {
     "Command": "Get-AdlAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2732,6 +2790,7 @@
   {
     "Command": "Update-AdlAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2786,6 +2845,7 @@
   {
     "Command": "Remove-AdlAnalyticsComputePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2834,6 +2894,7 @@
   {
     "Command": "Get-AdlJobPipeline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [
@@ -2870,6 +2931,7 @@
   {
     "Command": "Get-AdlJobRecurrence",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeAnalytics",
     "Version": "1.0.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataLakeStore.1.3.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataLakeStore.1.3.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDataLakeStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -32,6 +33,7 @@
   {
     "Command": "Remove-AzDataLakeStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -78,6 +80,7 @@
   {
     "Command": "Remove-AzDataLakeStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -124,6 +127,7 @@
   {
     "Command": "Set-AzDataLakeStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -170,6 +174,7 @@
   {
     "Command": "Add-AzDataLakeStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -216,6 +221,7 @@
   {
     "Command": "Get-AzDataLakeStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -246,6 +252,7 @@
   {
     "Command": "Set-AzDataLakeStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -296,6 +303,7 @@
   {
     "Command": "Add-AzDataLakeStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -346,6 +354,7 @@
   {
     "Command": "Get-AzDataLakeStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -372,6 +381,7 @@
   {
     "Command": "Set-AzDataLakeStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -414,6 +424,7 @@
   {
     "Command": "Add-AzDataLakeStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -456,6 +467,7 @@
   {
     "Command": "Remove-AzDataLakeStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -498,6 +510,7 @@
   {
     "Command": "Add-AzDataLakeStoreItemContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -532,6 +545,7 @@
   {
     "Command": "Enable-AzDataLakeStoreKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -571,6 +585,7 @@
   {
     "Command": "Export-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -637,6 +652,7 @@
   {
     "Command": "Get-AzDataLakeStoreChildItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -663,6 +679,7 @@
   {
     "Command": "Get-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -689,6 +706,7 @@
   {
     "Command": "Get-AzDataLakeStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -715,6 +733,7 @@
   {
     "Command": "Get-AzDataLakeStoreItemContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -777,6 +796,7 @@
   {
     "Command": "Get-AzDataLakeStoreItemOwner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -807,6 +827,7 @@
   {
     "Command": "Get-AzDataLakeStoreItemPermission",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -833,6 +854,7 @@
   {
     "Command": "Import-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -903,6 +925,7 @@
   {
     "Command": "Get-AzDataLakeStoreAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -927,6 +950,7 @@
   {
     "Command": "Join-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -975,6 +999,7 @@
   {
     "Command": "Move-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1021,6 +1046,7 @@
   {
     "Command": "New-AzDataLakeStoreAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1081,6 +1107,7 @@
   {
     "Command": "New-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1135,6 +1162,7 @@
   {
     "Command": "Remove-AzDataLakeStoreAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1179,6 +1207,7 @@
   {
     "Command": "Remove-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1229,6 +1258,7 @@
   {
     "Command": "Remove-AzDataLakeStoreItemAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1279,6 +1309,7 @@
   {
     "Command": "Remove-AzDataLakeStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1349,6 +1380,7 @@
   {
     "Command": "Set-AzDataLakeStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1423,6 +1455,7 @@
   {
     "Command": "Set-AzDataLakeStoreAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1475,6 +1508,7 @@
   {
     "Command": "Set-AzDataLakeStoreItemAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1533,6 +1567,7 @@
   {
     "Command": "Set-AzDataLakeStoreItemExpiry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1583,6 +1618,7 @@
   {
     "Command": "Set-AzDataLakeStoreItemOwner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1633,6 +1669,7 @@
   {
     "Command": "Set-AzDataLakeStoreItemPermission",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1675,6 +1712,7 @@
   {
     "Command": "Test-AzDataLakeStoreAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1699,6 +1737,7 @@
   {
     "Command": "Test-AzDataLakeStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1729,6 +1768,7 @@
   {
     "Command": "Export-AzDataLakeStoreChildItemProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1803,6 +1843,7 @@
   {
     "Command": "Get-AzDataLakeStoreChildItemSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1845,6 +1886,7 @@
   {
     "Command": "Get-AzDataLakeStoreDeletedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1879,6 +1921,7 @@
   {
     "Command": "Restore-AzDataLakeStoreDeletedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1941,6 +1984,7 @@
   {
     "Command": "Get-AdlStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -1971,6 +2015,7 @@
   {
     "Command": "Remove-AdlStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2017,6 +2062,7 @@
   {
     "Command": "Remove-AdlStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2063,6 +2109,7 @@
   {
     "Command": "Set-AdlStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2109,6 +2156,7 @@
   {
     "Command": "Add-AdlStoreTrustedIdProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2155,6 +2203,7 @@
   {
     "Command": "Get-AdlStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2185,6 +2234,7 @@
   {
     "Command": "Set-AdlStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2235,6 +2285,7 @@
   {
     "Command": "Add-AdlStoreFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2285,6 +2336,7 @@
   {
     "Command": "Get-AdlStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2311,6 +2363,7 @@
   {
     "Command": "Set-AdlStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2353,6 +2406,7 @@
   {
     "Command": "Add-AdlStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2395,6 +2449,7 @@
   {
     "Command": "Remove-AdlStoreVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2437,6 +2492,7 @@
   {
     "Command": "Add-AdlStoreItemContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2471,6 +2527,7 @@
   {
     "Command": "Export-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2537,6 +2594,7 @@
   {
     "Command": "Enable-AdlStoreKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2576,6 +2634,7 @@
   {
     "Command": "Get-AdlStoreChildItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2602,6 +2661,7 @@
   {
     "Command": "Get-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2628,6 +2688,7 @@
   {
     "Command": "Get-AdlStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2654,6 +2715,7 @@
   {
     "Command": "Get-AdlStoreItemContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2716,6 +2778,7 @@
   {
     "Command": "Get-AdlStoreItemOwner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2746,6 +2809,7 @@
   {
     "Command": "Get-AdlStoreItemPermission",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2772,6 +2836,7 @@
   {
     "Command": "Import-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2842,6 +2907,7 @@
   {
     "Command": "Get-AdlStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2866,6 +2932,7 @@
   {
     "Command": "Join-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2914,6 +2981,7 @@
   {
     "Command": "Move-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -2960,6 +3028,7 @@
   {
     "Command": "New-AdlStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3020,6 +3089,7 @@
   {
     "Command": "New-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3074,6 +3144,7 @@
   {
     "Command": "Remove-AdlStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3118,6 +3189,7 @@
   {
     "Command": "Remove-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3168,6 +3240,7 @@
   {
     "Command": "Remove-AdlStoreItemAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3218,6 +3291,7 @@
   {
     "Command": "Remove-AdlStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3288,6 +3362,7 @@
   {
     "Command": "Set-AdlStoreItemAclEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3362,6 +3437,7 @@
   {
     "Command": "Set-AdlStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3414,6 +3490,7 @@
   {
     "Command": "Set-AdlStoreItemAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3472,6 +3549,7 @@
   {
     "Command": "Set-AdlStoreItemExpiry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3522,6 +3600,7 @@
   {
     "Command": "Set-AdlStoreItemOwner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3572,6 +3651,7 @@
   {
     "Command": "Set-AdlStoreItemPermission",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3614,6 +3694,7 @@
   {
     "Command": "Test-AdlStore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3638,6 +3719,7 @@
   {
     "Command": "Test-AdlStoreItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3668,6 +3750,7 @@
   {
     "Command": "Get-AdlStoreChildItemSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3710,6 +3793,7 @@
   {
     "Command": "Export-AdlStoreChildItemProperties",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3784,6 +3868,7 @@
   {
     "Command": "Get-AdlStoreDeletedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3818,6 +3903,7 @@
   {
     "Command": "Restore-AdlStoreDeletedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [
@@ -3880,6 +3966,7 @@
   {
     "Command": "Export-AzDataLakeStoreChildItemProperties",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataLakeStore",
     "Version": "1.3.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataShare.1.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DataShare.1.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzDataShareAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -50,6 +51,7 @@
   {
     "Command": "Get-AzDataShareAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -78,6 +80,7 @@
   {
     "Command": "Remove-AzDataShareAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -134,6 +137,7 @@
   {
     "Command": "New-AzDataShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -182,6 +186,7 @@
   {
     "Command": "Get-AzDataShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -214,6 +219,7 @@
   {
     "Command": "Remove-AzDataShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -270,6 +276,7 @@
   {
     "Command": "Set-AzDataShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -326,6 +333,7 @@
   {
     "Command": "New-AzDataShareInvitation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -382,6 +390,7 @@
   {
     "Command": "Get-AzDataShareInvitation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -418,6 +427,7 @@
   {
     "Command": "Remove-AzDataShareInvitation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -474,6 +484,7 @@
   {
     "Command": "Get-AzDataShareReceivedInvitation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -498,6 +509,7 @@
   {
     "Command": "New-AzDataShareSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -546,6 +558,7 @@
   {
     "Command": "Get-AzDataShareSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -578,6 +591,7 @@
   {
     "Command": "Remove-AzDataShareSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -634,6 +648,7 @@
   {
     "Command": "New-AzDataShareSynchronizationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -686,6 +701,7 @@
   {
     "Command": "Get-AzDataShareSynchronizationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -722,6 +738,7 @@
   {
     "Command": "Remove-AzDataShareSynchronizationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -782,6 +799,7 @@
   {
     "Command": "New-AzDataShareTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -838,6 +856,7 @@
   {
     "Command": "Remove-AzDataShareTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -898,6 +917,7 @@
   {
     "Command": "Get-AzDataShareTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -934,6 +954,7 @@
   {
     "Command": "New-AzDataShareDataSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1006,6 +1027,7 @@
   {
     "Command": "Get-AzDataShareDataSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1042,6 +1064,7 @@
   {
     "Command": "Remove-AzDataShareDataSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1098,6 +1121,7 @@
   {
     "Command": "Start-AzDataShareSubscriptionSynchronization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1154,6 +1178,7 @@
   {
     "Command": "Stop-AzDataShareSubscriptionSynchronization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1210,6 +1235,7 @@
   {
     "Command": "Get-AzDataShareProviderShareSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1246,6 +1272,7 @@
   {
     "Command": "Revoke-AzDataShareSubscriptionAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1298,6 +1325,7 @@
   {
     "Command": "Grant-AzDataShareSubscriptionAccess",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1346,6 +1374,7 @@
   {
     "Command": "New-AzDataShareDataSetMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1414,6 +1443,7 @@
   {
     "Command": "Get-AzDataShareDataSetMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1450,6 +1480,7 @@
   {
     "Command": "Remove-AzDataShareDataSetMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1506,6 +1537,7 @@
   {
     "Command": "Get-AzDataShareSubscriptionSynchronization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1538,6 +1570,7 @@
   {
     "Command": "Get-AzDataShareSubscriptionSynchronizationDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1574,6 +1607,7 @@
   {
     "Command": "Get-AzDataShareSynchronization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1606,6 +1640,7 @@
   {
     "Command": "Get-AzDataShareSynchronizationDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [
@@ -1642,6 +1677,7 @@
   {
     "Command": "Get-AzDataShareSourceDataSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DataShare",
     "Version": "1.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Databricks.1.0.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Databricks.1.0.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDatabricksVNetPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -65,6 +66,7 @@
   {
     "Command": "Get-AzDatabricksWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -122,6 +124,7 @@
   {
     "Command": "New-AzDatabricksVNetPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -229,6 +232,7 @@
   {
     "Command": "New-AzDatabricksWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -338,6 +342,7 @@
   {
     "Command": "Remove-AzDatabricksVNetPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -421,6 +426,7 @@
   {
     "Command": "Remove-AzDatabricksWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -502,6 +508,7 @@
   {
     "Command": "Update-AzDatabricksVNetPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [
@@ -599,6 +606,7 @@
   {
     "Command": "Update-AzDatabricksWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Databricks",
     "Version": "1.0.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DeploymentManager.1.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DeploymentManager.1.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDeploymentManagerArtifactSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -34,6 +35,7 @@
   {
     "Command": "New-AzDeploymentManagerArtifactSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -86,6 +88,7 @@
   {
     "Command": "Set-AzDeploymentManagerArtifactSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -118,6 +121,7 @@
   {
     "Command": "Remove-AzDeploymentManagerArtifactSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -166,6 +170,7 @@
   {
     "Command": "Get-AzDeploymentManagerRollout",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -202,6 +207,7 @@
   {
     "Command": "Stop-AzDeploymentManagerRollout",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -250,6 +256,7 @@
   {
     "Command": "Restart-AzDeploymentManagerRollout",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -298,6 +305,7 @@
   {
     "Command": "Remove-AzDeploymentManagerRollout",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -346,6 +354,7 @@
   {
     "Command": "New-AzDeploymentManagerServiceTopology",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -394,6 +403,7 @@
   {
     "Command": "Get-AzDeploymentManagerServiceTopology",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -426,6 +436,7 @@
   {
     "Command": "Set-AzDeploymentManagerServiceTopology",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -458,6 +469,7 @@
   {
     "Command": "Remove-AzDeploymentManagerServiceTopology",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -506,6 +518,7 @@
   {
     "Command": "Get-AzDeploymentManagerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -550,6 +563,7 @@
   {
     "Command": "New-AzDeploymentManagerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -614,6 +628,7 @@
   {
     "Command": "Set-AzDeploymentManagerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -646,6 +661,7 @@
   {
     "Command": "Remove-AzDeploymentManagerService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -706,6 +722,7 @@
   {
     "Command": "Get-AzDeploymentManagerServiceUnit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -762,6 +779,7 @@
   {
     "Command": "New-AzDeploymentManagerServiceUnit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -858,6 +876,7 @@
   {
     "Command": "Set-AzDeploymentManagerServiceUnit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -890,6 +909,7 @@
   {
     "Command": "Remove-AzDeploymentManagerServiceUnit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -962,6 +982,7 @@
   {
     "Command": "Get-AzDeploymentManagerStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -994,6 +1015,7 @@
   {
     "Command": "New-AzDeploymentManagerStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -1050,6 +1072,7 @@
   {
     "Command": "Set-AzDeploymentManagerStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [
@@ -1082,6 +1105,7 @@
   {
     "Command": "Remove-AzDeploymentManagerStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DeploymentManager",
     "Version": "1.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DesktopVirtualization.2.0.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DesktopVirtualization.2.0.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Disconnect-AzWvdUserSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -83,6 +84,7 @@
   {
     "Command": "Expand-AzWvdMsixImage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -158,6 +160,7 @@
   {
     "Command": "Get-AzWvdApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -221,6 +224,7 @@
   {
     "Command": "Get-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -282,6 +286,7 @@
   {
     "Command": "Get-AzWvdDesktop",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -343,6 +348,7 @@
   {
     "Command": "Get-AzWvdHostPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -400,6 +406,7 @@
   {
     "Command": "Get-AzWvdMsixPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -461,6 +468,7 @@
   {
     "Command": "Get-AzWvdRegistrationInfo",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -512,6 +520,7 @@
   {
     "Command": "Get-AzWvdSessionHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -573,6 +582,7 @@
   {
     "Command": "Get-AzWvdStartMenuItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -624,6 +634,7 @@
   {
     "Command": "Get-AzWvdUserSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -693,6 +704,7 @@
   {
     "Command": "Get-AzWvdWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -750,6 +762,7 @@
   {
     "Command": "New-AzWvdApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -869,6 +882,7 @@
   {
     "Command": "New-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -958,6 +972,7 @@
   {
     "Command": "New-AzWvdHostPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1115,6 +1130,7 @@
   {
     "Command": "New-AzWvdMsixPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1232,6 +1248,7 @@
   {
     "Command": "New-AzWvdRegistrationInfo",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1299,6 +1316,7 @@
   {
     "Command": "New-AzWvdWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1384,6 +1402,7 @@
   {
     "Command": "Register-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1451,6 +1470,7 @@
   {
     "Command": "Remove-AzWvdApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1530,6 +1550,7 @@
   {
     "Command": "Remove-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1603,6 +1624,7 @@
   {
     "Command": "Remove-AzWvdHostPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1680,6 +1702,7 @@
   {
     "Command": "Remove-AzWvdMsixPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1757,6 +1780,7 @@
   {
     "Command": "Remove-AzWvdRegistrationInfo",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1820,6 +1844,7 @@
   {
     "Command": "Remove-AzWvdSessionHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1901,6 +1926,7 @@
   {
     "Command": "Remove-AzWvdUserSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -1986,6 +2012,7 @@
   {
     "Command": "Remove-AzWvdWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2059,6 +2086,7 @@
   {
     "Command": "Send-AzWvdUserSessionMessage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2146,6 +2174,7 @@
   {
     "Command": "Unregister-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2213,6 +2242,7 @@
   {
     "Command": "Update-AzWvdApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2336,6 +2366,7 @@
   {
     "Command": "Update-AzWvdApplicationGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2417,6 +2448,7 @@
   {
     "Command": "Update-AzWvdDesktop",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2502,6 +2534,7 @@
   {
     "Command": "Update-AzWvdHostPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2643,6 +2676,7 @@
   {
     "Command": "Update-AzWvdMsixPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2728,6 +2762,7 @@
   {
     "Command": "Update-AzWvdSessionHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [
@@ -2809,6 +2844,7 @@
   {
     "Command": "Update-AzWvdWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DesktopVirtualization",
     "Version": "2.0.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DevTestLabs.1.0.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.DevTestLabs.1.0.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDtlAllowedVMSizesPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -26,6 +27,7 @@
   {
     "Command": "Get-AzDtlAutoShutdownPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -50,6 +52,7 @@
   {
     "Command": "Get-AzDtlAutoStartPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -74,6 +77,7 @@
   {
     "Command": "Get-AzDtlVMsPerLabPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -98,6 +102,7 @@
   {
     "Command": "Get-AzDtlVMsPerUserPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -122,6 +127,7 @@
   {
     "Command": "Set-AzDtlAutoStartPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -174,6 +180,7 @@
   {
     "Command": "Set-AzDtlAutoShutdownPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -222,6 +229,7 @@
   {
     "Command": "Set-AzDtlVMsPerUserPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -270,6 +278,7 @@
   {
     "Command": "Set-AzDtlAllowedVMSizesPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [
@@ -318,6 +327,7 @@
   {
     "Command": "Set-AzDtlVMsPerLabPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.DevTestLabs",
     "Version": "1.0.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Dns.1.1.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Dns.1.1.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -38,6 +39,7 @@
   {
     "Command": "New-AzDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -114,6 +116,7 @@
   {
     "Command": "Remove-AzDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -174,6 +177,7 @@
   {
     "Command": "Set-AzDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -210,6 +214,7 @@
   {
     "Command": "Remove-AzDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -290,6 +295,7 @@
   {
     "Command": "Add-AzDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -370,6 +376,7 @@
   {
     "Command": "New-AzDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -438,6 +445,7 @@
   {
     "Command": "Get-AzDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -462,6 +470,7 @@
   {
     "Command": "Remove-AzDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -510,6 +519,7 @@
   {
     "Command": "Set-AzDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [
@@ -576,6 +586,7 @@
   {
     "Command": "New-AzDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Dns",
     "Version": "1.1.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.EventGrid.1.3.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.EventGrid.1.3.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzEventGridTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -70,6 +71,7 @@
   {
     "Command": "Get-AzEventGridTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -114,6 +116,7 @@
   {
     "Command": "Set-AzEventGridTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -174,6 +177,7 @@
   {
     "Command": "New-AzEventGridTopicKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -224,6 +228,7 @@
   {
     "Command": "Get-AzEventGridTopicKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -260,6 +265,7 @@
   {
     "Command": "Remove-AzEventGridTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -312,6 +318,7 @@
   {
     "Command": "New-AzEventGridSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -450,6 +457,7 @@
   {
     "Command": "Update-AzEventGridSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -572,6 +580,7 @@
   {
     "Command": "Remove-AzEventGridSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -642,6 +651,7 @@
   {
     "Command": "Get-AzEventGridSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -720,6 +730,7 @@
   {
     "Command": "Get-AzEventGridTopicType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -744,6 +755,7 @@
   {
     "Command": "New-AzEventGridDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -812,6 +824,7 @@
   {
     "Command": "Get-AzEventGridDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -856,6 +869,7 @@
   {
     "Command": "Get-AzEventGridDomainTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -906,6 +920,7 @@
   {
     "Command": "Get-AzEventGridDomainKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -942,6 +957,7 @@
   {
     "Command": "New-AzEventGridDomainKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -994,6 +1010,7 @@
   {
     "Command": "Remove-AzEventGridDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -1046,6 +1063,7 @@
   {
     "Command": "New-AzEventGridDomainTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [
@@ -1092,6 +1110,7 @@
   {
     "Command": "Remove-AzEventGridDomainTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventGrid",
     "Version": "1.3.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.EventHub.1.7.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.EventHub.1.7.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzEventHubNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -80,6 +81,7 @@
   {
     "Command": "Get-AzEventHubNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -106,6 +108,7 @@
   {
     "Command": "Set-AzEventHubNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -192,6 +195,7 @@
   {
     "Command": "Remove-AzEventHubNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -246,6 +250,7 @@
   {
     "Command": "New-AzEventHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -300,6 +305,7 @@
   {
     "Command": "Get-AzEventHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -342,6 +348,7 @@
   {
     "Command": "Set-AzEventHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -402,6 +409,7 @@
   {
     "Command": "Remove-AzEventHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -460,6 +468,7 @@
   {
     "Command": "Get-AzEventHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -502,6 +511,7 @@
   {
     "Command": "New-AzEventHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -562,6 +572,7 @@
   {
     "Command": "New-AzEventHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -620,6 +631,7 @@
   {
     "Command": "Get-AzEventHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -656,6 +668,7 @@
   {
     "Command": "Set-AzEventHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -714,6 +727,7 @@
   {
     "Command": "Remove-AzEventHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -774,6 +788,7 @@
   {
     "Command": "New-AzEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -828,6 +843,7 @@
   {
     "Command": "Get-AzEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -870,6 +886,7 @@
   {
     "Command": "Set-AzEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -924,6 +941,7 @@
   {
     "Command": "Remove-AzEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -990,6 +1008,7 @@
   {
     "Command": "New-AzEventHubGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1050,6 +1069,7 @@
   {
     "Command": "Get-AzEventHubGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1086,6 +1106,7 @@
   {
     "Command": "Remove-AzEventHubGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1142,6 +1163,7 @@
   {
     "Command": "Set-AzEventHubGeoDRConfigurationBreakPair",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1194,6 +1216,7 @@
   {
     "Command": "Set-AzEventHubGeoDRConfigurationFailOver",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1246,6 +1269,7 @@
   {
     "Command": "Test-AzEventHubName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1274,6 +1298,7 @@
   {
     "Command": "Remove-AzEventHubIPRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1328,6 +1353,7 @@
   {
     "Command": "Add-AzEventHubIPRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1378,6 +1404,7 @@
   {
     "Command": "Remove-AzEventHubVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1432,6 +1459,7 @@
   {
     "Command": "Add-AzEventHubVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1482,6 +1510,7 @@
   {
     "Command": "Get-AzEventHubNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1512,6 +1541,7 @@
   {
     "Command": "Remove-AzEventHubNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1566,6 +1596,7 @@
   {
     "Command": "Set-AzEventHubNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1630,6 +1661,7 @@
   {
     "Command": "New-AzEventHubAuthorizationRuleSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1676,6 +1708,7 @@
   {
     "Command": "New-AzEventHubCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1728,6 +1761,7 @@
   {
     "Command": "Set-AzEventHubCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1784,6 +1818,7 @@
   {
     "Command": "Get-AzEventHubCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1810,6 +1845,7 @@
   {
     "Command": "Remove-AzEventHubCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [
@@ -1862,6 +1898,7 @@
   {
     "Command": "Get-AzEventHubClustersAvailableRegion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.EventHub",
     "Version": "1.7.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.FrontDoor.1.6.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.FrontDoor.1.6.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzFrontDoor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -74,6 +75,7 @@
   {
     "Command": "Get-AzFrontDoor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -98,6 +100,7 @@
   {
     "Command": "Set-AzFrontDoor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -178,6 +181,7 @@
   {
     "Command": "Remove-AzFrontDoor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -226,6 +230,7 @@
   {
     "Command": "New-AzFrontDoorRoutingRuleObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -322,6 +327,7 @@
   {
     "Command": "New-AzFrontDoorBackendObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -382,6 +388,7 @@
   {
     "Command": "New-AzFrontDoorBackendPoolObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -422,6 +429,7 @@
   {
     "Command": "New-AzFrontDoorBackendPoolsSettingObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -446,6 +454,7 @@
   {
     "Command": "New-AzFrontDoorFrontendEndpointObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -510,6 +519,7 @@
   {
     "Command": "New-AzFrontDoorHealthProbeSettingObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -550,6 +560,7 @@
   {
     "Command": "New-AzFrontDoorLoadBalancingSettingObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -582,6 +593,7 @@
   {
     "Command": "New-AzFrontDoorWafMatchConditionObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -622,6 +634,7 @@
   {
     "Command": "New-AzFrontDoorWafCustomRuleObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -670,6 +683,7 @@
   {
     "Command": "New-AzFrontDoorWafManagedRuleObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -702,6 +716,7 @@
   {
     "Command": "New-AzFrontDoorWafPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -766,6 +781,7 @@
   {
     "Command": "Get-AzFrontDoorWafPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -790,6 +806,7 @@
   {
     "Command": "Update-AzFrontDoorWafPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -862,6 +879,7 @@
   {
     "Command": "Get-AzFrontDoorWafManagedRuleSetDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -878,6 +896,7 @@
   {
     "Command": "Remove-AzFrontDoorWafPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -926,6 +945,7 @@
   {
     "Command": "New-AzFrontDoorWafRuleGroupOverrideObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -954,6 +974,7 @@
   {
     "Command": "Remove-AzFrontDoorContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -998,6 +1019,7 @@
   {
     "Command": "Enable-AzFrontDoorCustomDomainHttps",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1062,6 +1084,7 @@
   {
     "Command": "Disable-AzFrontDoorCustomDomainHttps",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1110,6 +1133,7 @@
   {
     "Command": "Get-AzFrontDoorFrontendEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1146,6 +1170,7 @@
   {
     "Command": "New-AzFrontDoorWafManagedRuleOverrideObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1178,6 +1203,7 @@
   {
     "Command": "New-AzFrontDoorWafManagedRuleExclusionObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1206,6 +1232,7 @@
   {
     "Command": "New-AzFrontDoorRulesEngine",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1250,6 +1277,7 @@
   {
     "Command": "New-AzFrontDoorRulesEngineRuleObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1286,6 +1314,7 @@
   {
     "Command": "New-AzFrontDoorRulesEngineActionObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1366,6 +1395,7 @@
   {
     "Command": "New-AzFrontDoorHeaderActionObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1394,6 +1424,7 @@
   {
     "Command": "New-AzFrontDoorRulesEngineMatchConditionObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1434,6 +1465,7 @@
   {
     "Command": "Get-AzFrontDoorRulesEngine",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1462,6 +1494,7 @@
   {
     "Command": "Set-AzFrontDoorRulesEngine",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [
@@ -1514,6 +1547,7 @@
   {
     "Command": "Remove-AzFrontDoorRulesEngine",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.FrontDoor",
     "Version": "1.6.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Functions.2.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Functions.2.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -61,6 +62,7 @@
   {
     "Command": "Get-AzFunctionAppAvailableLocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -112,6 +114,7 @@
   {
     "Command": "Get-AzFunctionAppPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -167,6 +170,7 @@
   {
     "Command": "Get-AzFunctionAppSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -234,6 +238,7 @@
   {
     "Command": "New-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -379,6 +384,7 @@
   {
     "Command": "New-AzFunctionAppPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -478,6 +484,7 @@
   {
     "Command": "Remove-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -553,6 +560,7 @@
   {
     "Command": "Remove-AzFunctionAppPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -628,6 +636,7 @@
   {
     "Command": "Remove-AzFunctionAppSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -703,6 +712,7 @@
   {
     "Command": "Restart-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -778,6 +788,7 @@
   {
     "Command": "Start-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -849,6 +860,7 @@
   {
     "Command": "Stop-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -924,6 +936,7 @@
   {
     "Command": "Update-AzFunctionApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -1027,6 +1040,7 @@
   {
     "Command": "Update-AzFunctionAppPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [
@@ -1122,6 +1136,7 @@
   {
     "Command": "Update-AzFunctionAppSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Functions",
     "Version": "2.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.HDInsight.4.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.HDInsight.4.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzHDInsightJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -40,6 +41,7 @@
   {
     "Command": "New-AzHDInsightSqoopJobDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -76,6 +78,7 @@
   {
     "Command": "Wait-AzHDInsightJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -118,6 +121,7 @@
   {
     "Command": "New-AzHDInsightStreamingMapReduceJobDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -174,6 +178,7 @@
   {
     "Command": "New-AzHDInsightMapReduceJobDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -222,6 +227,7 @@
   {
     "Command": "New-AzHDInsightPigJobDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -258,6 +264,7 @@
   {
     "Command": "New-AzHDInsightHiveJobDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -306,6 +313,7 @@
   {
     "Command": "Get-AzHDInsightJobOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -356,6 +364,7 @@
   {
     "Command": "Invoke-AzHDInsightHiveJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -416,6 +425,7 @@
   {
     "Command": "Use-AzHDInsightCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -446,6 +456,7 @@
   {
     "Command": "Stop-AzHDInsightJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -480,6 +491,7 @@
   {
     "Command": "Start-AzHDInsightJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -514,6 +526,7 @@
   {
     "Command": "Add-AzHDInsightComponentVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -554,6 +567,7 @@
   {
     "Command": "Add-AzHDInsightSecurityProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -606,6 +620,7 @@
   {
     "Command": "Set-AzHDInsightDefaultStorage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -638,6 +653,7 @@
   {
     "Command": "Add-AzHDInsightStorage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -666,6 +682,7 @@
   {
     "Command": "Add-AzHDInsightScriptAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -702,6 +719,7 @@
   {
     "Command": "Add-AzHDInsightMetastore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -738,6 +756,7 @@
   {
     "Command": "Add-AzHDInsightConfigValue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -830,6 +849,7 @@
   {
     "Command": "Get-AzHDInsightProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -850,6 +870,7 @@
   {
     "Command": "Set-AzHDInsightGatewayCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -904,6 +925,7 @@
   {
     "Command": "New-AzHDInsightClusterConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1020,6 +1042,7 @@
   {
     "Command": "Remove-AzHDInsightCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1048,6 +1071,7 @@
   {
     "Command": "Set-AzHDInsightClusterSize",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1076,6 +1100,7 @@
   {
     "Command": "Get-AzHDInsightPersistedScriptAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1104,6 +1129,7 @@
   {
     "Command": "Get-AzHDInsightScriptActionHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1132,6 +1158,7 @@
   {
     "Command": "Remove-AzHDInsightPersistedScriptAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1160,6 +1187,7 @@
   {
     "Command": "Set-AzHDInsightPersistedScriptAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1188,6 +1216,7 @@
   {
     "Command": "Submit-AzHDInsightScriptAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1236,6 +1265,7 @@
   {
     "Command": "Get-AzHDInsightCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1260,6 +1290,7 @@
   {
     "Command": "New-AzHDInsightCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1504,6 +1535,7 @@
   {
     "Command": "Add-AzHDInsightClusterIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1548,6 +1580,7 @@
   {
     "Command": "Enable-AzHDInsightMonitoring",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1594,6 +1627,7 @@
   {
     "Command": "Disable-AzHDInsightMonitoring",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1632,6 +1666,7 @@
   {
     "Command": "Get-AzHDInsightMonitoring",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1658,6 +1693,7 @@
   {
     "Command": "Set-AzHDInsightClusterDiskEncryptionKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1716,6 +1752,7 @@
   {
     "Command": "Get-AzHDInsightHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1748,6 +1785,7 @@
   {
     "Command": "Restart-AzHDInsightHost",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1804,6 +1842,7 @@
   {
     "Command": "New-AzHDInsightClusterAutoscaleScheduleCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1832,6 +1871,7 @@
   {
     "Command": "Get-AzHDInsightClusterAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1864,6 +1904,7 @@
   {
     "Command": "New-AzHDInsightClusterAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1896,6 +1937,7 @@
   {
     "Command": "Set-AzHDInsightClusterAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [
@@ -1968,6 +2010,7 @@
   {
     "Command": "Remove-AzHDInsightClusterAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HDInsight",
     "Version": "4.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.HealthcareApis.1.2.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.HealthcareApis.1.2.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzHealthcareApisService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HealthcareApis",
     "Version": "1.2.0",
     "Parameters": [
@@ -116,6 +117,7 @@
   {
     "Command": "Remove-AzHealthcareApisService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HealthcareApis",
     "Version": "1.2.0",
     "Parameters": [
@@ -171,6 +173,7 @@
   {
     "Command": "Set-AzHealthcareApisService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HealthcareApis",
     "Version": "1.2.0",
     "Parameters": [
@@ -293,6 +296,7 @@
   {
     "Command": "Get-AzHealthcareApisService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.HealthcareApis",
     "Version": "1.2.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.IotHub.2.7.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.IotHub.2.7.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzIotHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -58,6 +59,7 @@
   {
     "Command": "Get-AzIotHubEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -82,6 +84,7 @@
   {
     "Command": "Get-AzIotHubConnectionString",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -110,6 +113,7 @@
   {
     "Command": "Get-AzIotHubJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -138,6 +142,7 @@
   {
     "Command": "Get-AzIotHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -170,6 +175,7 @@
   {
     "Command": "Get-AzIotHubQuotaMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -194,6 +200,7 @@
   {
     "Command": "Get-AzIotHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -218,6 +225,7 @@
   {
     "Command": "Get-AzIotHubRegistryStatistic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -242,6 +250,7 @@
   {
     "Command": "Get-AzIotHubValidSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -266,6 +275,7 @@
   {
     "Command": "Add-AzIotHubEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -306,6 +316,7 @@
   {
     "Command": "New-AzIotHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -362,6 +373,7 @@
   {
     "Command": "New-AzIotHubExportDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -406,6 +418,7 @@
   {
     "Command": "New-AzIotHubImportDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -450,6 +463,7 @@
   {
     "Command": "Remove-AzIotHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -486,6 +500,7 @@
   {
     "Command": "Remove-AzIotHubEventHubConsumerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -526,6 +541,7 @@
   {
     "Command": "Remove-AzIotHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -570,6 +586,7 @@
   {
     "Command": "Set-AzIotHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -658,6 +675,7 @@
   {
     "Command": "Update-AzIotHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -702,6 +720,7 @@
   {
     "Command": "Add-AzIotHubCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -758,6 +777,7 @@
   {
     "Command": "Get-AzIotHubCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -794,6 +814,7 @@
   {
     "Command": "Get-AzIotHubCertificateVerificationCode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -834,6 +855,7 @@
   {
     "Command": "Set-AzIotHubVerifiedCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -890,6 +912,7 @@
   {
     "Command": "Remove-AzIotHubCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -946,6 +969,7 @@
   {
     "Command": "Get-AzIotHubRoutingEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -986,6 +1010,7 @@
   {
     "Command": "Add-AzIotHubRoutingEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1050,6 +1075,7 @@
   {
     "Command": "Remove-AzIotHubRoutingEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1106,6 +1132,7 @@
   {
     "Command": "Get-AzIotHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1142,6 +1169,7 @@
   {
     "Command": "Add-AzIotHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1206,6 +1234,7 @@
   {
     "Command": "Remove-AzIotHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1258,6 +1287,7 @@
   {
     "Command": "Set-AzIotHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1322,6 +1352,7 @@
   {
     "Command": "Test-AzIotHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1378,6 +1409,7 @@
   {
     "Command": "New-AzIotHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1426,6 +1458,7 @@
   {
     "Command": "Invoke-AzIotHubManualFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1478,6 +1511,7 @@
   {
     "Command": "Add-AzIotHubMessageEnrichment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1534,6 +1568,7 @@
   {
     "Command": "Get-AzIotHubMessageEnrichment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1570,6 +1605,7 @@
   {
     "Command": "Remove-AzIotHubMessageEnrichment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1622,6 +1658,7 @@
   {
     "Command": "Set-AzIotHubMessageEnrichment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1678,6 +1715,7 @@
   {
     "Command": "Add-AzIotHubDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1754,6 +1792,7 @@
   {
     "Command": "Get-AzIotHubDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1790,6 +1829,7 @@
   {
     "Command": "Remove-AzIotHubDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1842,6 +1882,7 @@
   {
     "Command": "Set-AzIotHubDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1906,6 +1947,7 @@
   {
     "Command": "Add-AzIotHubModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -1962,6 +2004,7 @@
   {
     "Command": "Get-AzIotHubModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2002,6 +2045,7 @@
   {
     "Command": "Remove-AzIotHubModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2058,6 +2102,7 @@
   {
     "Command": "Set-AzIotHubModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2114,6 +2159,7 @@
   {
     "Command": "Get-AzIotHubDeviceConnectionString",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2154,6 +2200,7 @@
   {
     "Command": "Get-AzIotHubModuleConnectionString",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2198,6 +2245,7 @@
   {
     "Command": "Get-AzIotHubDeviceParent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2234,6 +2282,7 @@
   {
     "Command": "Set-AzIotHubDeviceParent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2290,6 +2339,7 @@
   {
     "Command": "Add-AzIotHubDeviceChildren",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2346,6 +2396,7 @@
   {
     "Command": "Remove-AzIotHubDeviceChildren",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2402,6 +2453,7 @@
   {
     "Command": "Get-AzIotHubDeviceChildren",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2438,6 +2490,7 @@
   {
     "Command": "Get-AzIotHubDistributedTracing",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2474,6 +2527,7 @@
   {
     "Command": "Set-AzIotHubDistributedTracing",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2534,6 +2588,7 @@
   {
     "Command": "Get-AzIotHubDeviceTwin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2570,6 +2625,7 @@
   {
     "Command": "Update-AzIotHubDeviceTwin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2630,6 +2686,7 @@
   {
     "Command": "Invoke-AzIotHubDeviceMethod",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2694,6 +2751,7 @@
   {
     "Command": "Get-AzIotHubModuleTwin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2734,6 +2792,7 @@
   {
     "Command": "Update-AzIotHubModuleTwin",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2798,6 +2857,7 @@
   {
     "Command": "Add-AzIotHubConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2866,6 +2926,7 @@
   {
     "Command": "Get-AzIotHubConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2902,6 +2963,7 @@
   {
     "Command": "Remove-AzIotHubConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -2954,6 +3016,7 @@
   {
     "Command": "Set-AzIotHubConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3022,6 +3085,7 @@
   {
     "Command": "Invoke-AzIotHubModuleMethod",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3090,6 +3154,7 @@
   {
     "Command": "Invoke-AzIotHubQuery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3142,6 +3207,7 @@
   {
     "Command": "New-AzIotHubSasToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3206,6 +3272,7 @@
   {
     "Command": "Invoke-AzIotHubConfigurationMetricsQuery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3262,6 +3329,7 @@
   {
     "Command": "Add-AzIotHubDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3330,6 +3398,7 @@
   {
     "Command": "Get-AzIotHubDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3366,6 +3435,7 @@
   {
     "Command": "Remove-AzIotHubDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3418,6 +3488,7 @@
   {
     "Command": "Set-AzIotHubDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3486,6 +3557,7 @@
   {
     "Command": "Invoke-AzIotHubDeploymentMetricsQuery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3542,6 +3614,7 @@
   {
     "Command": "Set-AzIotHubEdgeModule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3594,6 +3667,7 @@
   {
     "Command": "Send-AzIotHubDevice2CloudMessage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3654,6 +3728,7 @@
   {
     "Command": "Get-AzIotHubEHCG",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3678,6 +3753,7 @@
   {
     "Command": "Add-AzIotHubEHCG",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3718,6 +3794,7 @@
   {
     "Command": "Remove-AzIotHubEHCG",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3758,6 +3835,7 @@
   {
     "Command": "Set-AzIotHubVC",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3814,6 +3892,7 @@
   {
     "Command": "Get-AzIotHubCVC",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3854,6 +3933,7 @@
   {
     "Command": "Add-AzIotHubMsgEnrich",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3910,6 +3990,7 @@
   {
     "Command": "Get-AzIotHubMsgEnrich",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3946,6 +4027,7 @@
   {
     "Command": "Remove-AzIotHubMsgEnrich",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -3998,6 +4080,7 @@
   {
     "Command": "Set-AzIotHubMsgEnrich",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4054,6 +4137,7 @@
   {
     "Command": "Get-AzIotHubDCS",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4094,6 +4178,7 @@
   {
     "Command": "Get-AzIotHubMCS",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4138,6 +4223,7 @@
   {
     "Command": "Add-AzIotHubDCL",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4194,6 +4280,7 @@
   {
     "Command": "Remove-AzIotHubDCL",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4250,6 +4337,7 @@
   {
     "Command": "Get-AzIotHubDCL",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4286,6 +4374,7 @@
   {
     "Command": "Get-AzIotHubTracing",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4322,6 +4411,7 @@
   {
     "Command": "Set-AzIotHubTracing",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4382,6 +4472,7 @@
   {
     "Command": "Invoke-AzIotHubConfigMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4438,6 +4529,7 @@
   {
     "Command": "Invoke-AzIotHubDeployMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [
@@ -4494,6 +4586,7 @@
   {
     "Command": "Send-AzIotHubD2CMessage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.IotHub",
     "Version": "2.7.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.KeyVault.3.2.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.KeyVault.3.2.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -50,6 +51,7 @@
   {
     "Command": "Update-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -110,6 +112,7 @@
   {
     "Command": "Stop-AzKeyVaultCertificateOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -156,6 +159,7 @@
   {
     "Command": "Get-AzKeyVaultCertificateOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -186,6 +190,7 @@
   {
     "Command": "Import-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -244,6 +249,7 @@
   {
     "Command": "Add-AzKeyVaultCertificateContact",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -292,6 +298,7 @@
   {
     "Command": "Get-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -344,6 +351,7 @@
   {
     "Command": "Get-AzKeyVaultCertificateContact",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -372,6 +380,7 @@
   {
     "Command": "Get-AzKeyVaultCertificateIssuer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -406,6 +415,7 @@
   {
     "Command": "New-AzKeyVaultCertificatePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -512,6 +522,7 @@
   {
     "Command": "Remove-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -564,6 +575,7 @@
   {
     "Command": "Remove-AzKeyVaultCertificateContact",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -612,6 +624,7 @@
   {
     "Command": "Remove-AzKeyVaultCertificateIssuer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -662,6 +675,7 @@
   {
     "Command": "Remove-AzKeyVaultCertificateOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -712,6 +726,7 @@
   {
     "Command": "Set-AzKeyVaultCertificateIssuer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -776,6 +791,7 @@
   {
     "Command": "Set-AzKeyVaultCertificatePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -902,6 +918,7 @@
   {
     "Command": "Get-AzKeyVaultManagedHsm",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -932,6 +949,7 @@
   {
     "Command": "New-AzKeyVaultManagedHsm",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -992,6 +1010,7 @@
   {
     "Command": "Remove-AzKeyVaultManagedHsm",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1050,6 +1069,7 @@
   {
     "Command": "Update-AzKeyVaultManagedHsm",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1102,6 +1122,7 @@
   {
     "Command": "Get-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1140,6 +1161,7 @@
   {
     "Command": "New-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1220,6 +1242,7 @@
   {
     "Command": "Remove-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1286,6 +1309,7 @@
   {
     "Command": "Undo-AzKeyVaultRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1334,6 +1358,7 @@
   {
     "Command": "Backup-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1386,6 +1411,7 @@
   {
     "Command": "Restore-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1446,6 +1472,7 @@
   {
     "Command": "Get-AzKeyVaultRoleDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1476,6 +1503,7 @@
   {
     "Command": "Get-AzKeyVaultRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1537,6 +1565,7 @@
   {
     "Command": "New-AzKeyVaultRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1606,6 +1635,7 @@
   {
     "Command": "Remove-AzKeyVaultRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1687,6 +1717,7 @@
   {
     "Command": "Remove-AzKeyVaultAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1771,6 +1802,7 @@
   {
     "Command": "Set-AzKeyVaultAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1875,6 +1907,7 @@
   {
     "Command": "Backup-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1931,6 +1964,7 @@
   {
     "Command": "Get-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -1995,6 +2029,7 @@
   {
     "Command": "Get-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2043,6 +2078,7 @@
   {
     "Command": "Undo-AzKeyVaultKeyRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2089,6 +2125,7 @@
   {
     "Command": "Undo-AzKeyVaultSecretRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2131,6 +2168,7 @@
   {
     "Command": "Add-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2235,6 +2273,7 @@
   {
     "Command": "Remove-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2293,6 +2332,7 @@
   {
     "Command": "Update-AzKeyVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2353,6 +2393,7 @@
   {
     "Command": "New-AzKeyVaultNetworkRuleSetObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2385,6 +2426,7 @@
   {
     "Command": "Remove-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2439,6 +2481,7 @@
   {
     "Command": "Restore-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2495,6 +2538,7 @@
   {
     "Command": "Update-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2573,6 +2617,7 @@
   {
     "Command": "Set-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2641,6 +2686,7 @@
   {
     "Command": "Update-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2715,6 +2761,7 @@
   {
     "Command": "Get-AzKeyVaultCertificatePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2745,6 +2792,7 @@
   {
     "Command": "New-AzKeyVaultCertificateAdministratorDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2789,6 +2837,7 @@
   {
     "Command": "New-AzKeyVaultCertificateOrganizationDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2825,6 +2874,7 @@
   {
     "Command": "Backup-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2877,6 +2927,7 @@
   {
     "Command": "Restore-AzKeyVaultSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2921,6 +2972,7 @@
   {
     "Command": "Get-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -2960,6 +3012,7 @@
   {
     "Command": "Add-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3027,6 +3080,7 @@
   {
     "Command": "Remove-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3082,6 +3136,7 @@
   {
     "Command": "Update-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3151,6 +3206,7 @@
   {
     "Command": "Update-AzKeyVaultManagedStorageAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3206,6 +3262,7 @@
   {
     "Command": "Get-AzKeyVaultManagedStorageSasDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3246,6 +3303,7 @@
   {
     "Command": "Set-AzKeyVaultManagedStorageSasDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3316,6 +3374,7 @@
   {
     "Command": "Remove-AzKeyVaultManagedStorageSasDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3372,6 +3431,7 @@
   {
     "Command": "Undo-AzKeyVaultCertificateRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3414,6 +3474,7 @@
   {
     "Command": "Backup-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3466,6 +3527,7 @@
   {
     "Command": "Restore-AzKeyVaultCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3510,6 +3572,7 @@
   {
     "Command": "Backup-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3562,6 +3625,7 @@
   {
     "Command": "Restore-AzKeyVaultManagedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3606,6 +3670,7 @@
   {
     "Command": "Undo-AzKeyVaultManagedStorageSasDefinitionRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3654,6 +3719,7 @@
   {
     "Command": "Undo-AzKeyVaultManagedStorageAccountRemoval",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3696,6 +3762,7 @@
   {
     "Command": "Add-AzKeyVaultNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3752,6 +3819,7 @@
   {
     "Command": "Update-AzKeyVaultNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3816,6 +3884,7 @@
   {
     "Command": "Remove-AzKeyVaultNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3872,6 +3941,7 @@
   {
     "Command": "Export-AzKeyVaultSecurityDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3930,6 +4000,7 @@
   {
     "Command": "Import-AzKeyVaultSecurityDomain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -3982,6 +4053,7 @@
   {
     "Command": "Set-AzKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -4060,6 +4132,7 @@
   {
     "Command": "Set-AzKeyVaultSecretAttribute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -4134,6 +4207,7 @@
   {
     "Command": "Set-AzKeyVaultKeyAttribute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [
@@ -4212,6 +4286,7 @@
   {
     "Command": "Set-AzKeyVaultCertificateAttribute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.KeyVault",
     "Version": "3.2.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Kusto.1.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Kusto.1.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzKustoClusterLanguageExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -85,6 +86,7 @@
   {
     "Command": "Add-AzKustoDatabasePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -160,6 +162,7 @@
   {
     "Command": "Get-AzKustoAttachedDatabaseConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -221,6 +224,7 @@
   {
     "Command": "Get-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -278,6 +282,7 @@
   {
     "Command": "Get-AzKustoClusterFollowerDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -341,6 +346,7 @@
   {
     "Command": "Get-AzKustoClusterLanguageExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -404,6 +410,7 @@
   {
     "Command": "Get-AzKustoClusterPrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -463,6 +470,7 @@
   {
     "Command": "Get-AzKustoClusterSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -514,6 +522,7 @@
   {
     "Command": "Get-AzKustoDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -575,6 +584,7 @@
   {
     "Command": "Get-AzKustoDatabasePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -642,6 +652,7 @@
   {
     "Command": "Get-AzKustoDatabasePrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -705,6 +716,7 @@
   {
     "Command": "Get-AzKustoDataConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -770,6 +782,7 @@
   {
     "Command": "Invoke-AzKustoDataConnectionValidation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -901,6 +914,7 @@
   {
     "Command": "Invoke-AzKustoDetachClusterFollowerDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -988,6 +1002,7 @@
   {
     "Command": "Invoke-AzKustoDiagnoseClusterVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1063,6 +1078,7 @@
   {
     "Command": "New-AzKustoAttachedDatabaseConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1156,6 +1172,7 @@
   {
     "Command": "New-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1325,6 +1342,7 @@
   {
     "Command": "New-AzKustoClusterPrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1416,6 +1434,7 @@
   {
     "Command": "New-AzKustoDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1509,6 +1528,7 @@
   {
     "Command": "New-AzKustoDatabasePrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1604,6 +1624,7 @@
   {
     "Command": "New-AzKustoDataConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1741,6 +1762,7 @@
   {
     "Command": "Remove-AzKustoAttachedDatabaseConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1826,6 +1848,7 @@
   {
     "Command": "Remove-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1907,6 +1930,7 @@
   {
     "Command": "Remove-AzKustoClusterLanguageExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -1990,6 +2014,7 @@
   {
     "Command": "Remove-AzKustoClusterPrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2073,6 +2098,7 @@
   {
     "Command": "Remove-AzKustoDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2158,6 +2184,7 @@
   {
     "Command": "Remove-AzKustoDatabasePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2233,6 +2260,7 @@
   {
     "Command": "Remove-AzKustoDatabasePrincipalAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2320,6 +2348,7 @@
   {
     "Command": "Remove-AzKustoDataConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2409,6 +2438,7 @@
   {
     "Command": "Start-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2490,6 +2520,7 @@
   {
     "Command": "Stop-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2571,6 +2602,7 @@
   {
     "Command": "Test-AzKustoClusterNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2642,6 +2674,7 @@
   {
     "Command": "Test-AzKustoClusterPrincipalAssignmentNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2717,6 +2750,7 @@
   {
     "Command": "Test-AzKustoDatabaseNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2792,6 +2826,7 @@
   {
     "Command": "Test-AzKustoDatabasePrincipalAssignmentNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2871,6 +2906,7 @@
   {
     "Command": "Test-AzKustoDataConnectionNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -2950,6 +2986,7 @@
   {
     "Command": "Update-AzKustoCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -3119,6 +3156,7 @@
   {
     "Command": "Update-AzKustoDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [
@@ -3216,6 +3254,7 @@
   {
     "Command": "Update-AzKustoDataConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Kusto",
     "Version": "1.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.LogicApp.1.4.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.LogicApp.1.4.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzIntegrationAccountAgreement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -33,6 +34,7 @@
   {
     "Command": "Get-AzIntegrationAccountAssembly",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -74,6 +76,7 @@
   {
     "Command": "Get-AzIntegrationAccountBatchConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -115,6 +118,7 @@
   {
     "Command": "Get-AzIntegrationAccountCallbackUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -146,6 +150,7 @@
   {
     "Command": "Get-AzIntegrationAccountCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -177,6 +182,7 @@
   {
     "Command": "Get-AzIntegrationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -204,6 +210,7 @@
   {
     "Command": "Get-AzIntegrationAccountMap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -239,6 +246,7 @@
   {
     "Command": "Get-AzIntegrationAccountPartner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -270,6 +278,7 @@
   {
     "Command": "Get-AzIntegrationAccountSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -301,6 +310,7 @@
   {
     "Command": "Get-AzIntegrationAccountGeneratedIcn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -337,6 +347,7 @@
   {
     "Command": "Get-AzIntegrationAccountReceivedIcn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -377,6 +388,7 @@
   {
     "Command": "New-AzIntegrationAccountAgreement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -460,6 +472,7 @@
   {
     "Command": "New-AzIntegrationAccountAssembly",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -529,6 +542,7 @@
   {
     "Command": "New-AzIntegrationAccountBatchConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -622,6 +636,7 @@
   {
     "Command": "New-AzIntegrationAccountCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -685,6 +700,7 @@
   {
     "Command": "New-AzIntegrationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -732,6 +748,7 @@
   {
     "Command": "New-AzIntegrationAccountMap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -795,6 +812,7 @@
   {
     "Command": "New-AzIntegrationAccountPartner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -850,6 +868,7 @@
   {
     "Command": "New-AzIntegrationAccountSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -913,6 +932,7 @@
   {
     "Command": "Remove-AzIntegrationAccountAgreement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -960,6 +980,7 @@
   {
     "Command": "Remove-AzIntegrationAccountAssembly",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1017,6 +1038,7 @@
   {
     "Command": "Remove-AzIntegrationAccountBatchConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1074,6 +1096,7 @@
   {
     "Command": "Remove-AzIntegrationAccountCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1121,6 +1144,7 @@
   {
     "Command": "Remove-AzIntegrationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1164,6 +1188,7 @@
   {
     "Command": "Remove-AzIntegrationAccountMap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1211,6 +1236,7 @@
   {
     "Command": "Remove-AzIntegrationAccountPartner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1258,6 +1284,7 @@
   {
     "Command": "Remove-AzIntegrationAccountSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1305,6 +1332,7 @@
   {
     "Command": "Remove-AzIntegrationAccountReceivedIcn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1358,6 +1386,7 @@
   {
     "Command": "Set-AzIntegrationAccountAgreement",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1445,6 +1474,7 @@
   {
     "Command": "Set-AzIntegrationAccountAssembly",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1514,6 +1544,7 @@
   {
     "Command": "Set-AzIntegrationAccountBatchConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1607,6 +1638,7 @@
   {
     "Command": "Set-AzIntegrationAccountCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1674,6 +1706,7 @@
   {
     "Command": "Set-AzIntegrationAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1725,6 +1758,7 @@
   {
     "Command": "Set-AzIntegrationAccountMap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1792,6 +1826,7 @@
   {
     "Command": "Set-AzIntegrationAccountPartner",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1851,6 +1886,7 @@
   {
     "Command": "Set-AzIntegrationAccountSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1918,6 +1954,7 @@
   {
     "Command": "Stop-AzLogicAppRun",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -1964,6 +2001,7 @@
   {
     "Command": "Set-AzIntegrationAccountGeneratedIcn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2016,6 +2054,7 @@
   {
     "Command": "Set-AzIntegrationAccountReceivedIcn",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2072,6 +2111,7 @@
   {
     "Command": "Get-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2102,6 +2142,7 @@
   {
     "Command": "Get-AzLogicAppRunAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2136,6 +2177,7 @@
   {
     "Command": "Get-AzLogicAppRunHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2178,6 +2220,7 @@
   {
     "Command": "Get-AzLogicAppTriggerCallbackUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2208,6 +2251,7 @@
   {
     "Command": "Get-AzLogicAppTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2238,6 +2282,7 @@
   {
     "Command": "Get-AzLogicAppTriggerHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2272,6 +2317,7 @@
   {
     "Command": "Get-AzLogicAppUpgradedDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2302,6 +2348,7 @@
   {
     "Command": "New-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2368,6 +2415,7 @@
   {
     "Command": "Remove-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2410,6 +2458,7 @@
   {
     "Command": "Start-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2456,6 +2505,7 @@
   {
     "Command": "Set-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [
@@ -2530,6 +2580,7 @@
   {
     "Command": "Test-AzLogicApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.LogicApp",
     "Version": "1.4.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.MachineLearning.1.1.3.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.MachineLearning.1.1.3.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Move-AzMlCommitmentAssociation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -46,6 +47,7 @@
   {
     "Command": "Get-AzMlCommitmentAssociation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -74,6 +76,7 @@
   {
     "Command": "Get-AzMlCommitmentPlanUsageHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -98,6 +101,7 @@
   {
     "Command": "Remove-AzMlCommitmentPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -142,6 +146,7 @@
   {
     "Command": "Update-AzMlCommitmentPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -198,6 +203,7 @@
   {
     "Command": "Get-AzMlCommitmentPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -222,6 +228,7 @@
   {
     "Command": "Remove-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -266,6 +273,7 @@
   {
     "Command": "Get-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -294,6 +302,7 @@
   {
     "Command": "Update-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -386,6 +395,7 @@
   {
     "Command": "Export-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -430,6 +440,7 @@
   {
     "Command": "Get-AzMlWebServiceKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -458,6 +469,7 @@
   {
     "Command": "Import-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -482,6 +494,7 @@
   {
     "Command": "New-AzMlCommitmentPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -538,6 +551,7 @@
   {
     "Command": "New-AzMlWebService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -590,6 +604,7 @@
   {
     "Command": "Add-AzMlWebServiceRegionalProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [
@@ -634,6 +649,7 @@
   {
     "Command": "Get-AzMlWebServiceKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MachineLearning",
     "Version": "1.1.3",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Maintenance.1.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Maintenance.1.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzApplyUpdate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -46,6 +47,7 @@
   {
     "Command": "Get-AzConfigurationAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -86,6 +88,7 @@
   {
     "Command": "Get-AzMaintenanceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -110,6 +113,7 @@
   {
     "Command": "Get-AzMaintenanceUpdate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "New-AzApplyUpdate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -206,6 +211,7 @@
   {
     "Command": "New-AzConfigurationAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -278,6 +284,7 @@
   {
     "Command": "New-AzMaintenanceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -358,6 +365,7 @@
   {
     "Command": "Remove-AzConfigurationAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -426,6 +434,7 @@
   {
     "Command": "Remove-AzMaintenanceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -474,6 +483,7 @@
   {
     "Command": "Update-AzMaintenanceConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [
@@ -518,6 +528,7 @@
   {
     "Command": "Get-AzMaintenancePublicConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Maintenance",
     "Version": "1.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ManagedServices.2.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ManagedServices.2.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzManagedServicesAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "New-AzManagedServicesAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [
@@ -78,6 +80,7 @@
   {
     "Command": "Remove-AzManagedServicesAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [
@@ -126,6 +129,7 @@
   {
     "Command": "Get-AzManagedServicesDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "New-AzManagedServicesDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [
@@ -226,6 +231,7 @@
   {
     "Command": "Remove-AzManagedServicesDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ManagedServices",
     "Version": "2.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.MarketplaceOrdering.1.0.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.MarketplaceOrdering.1.0.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzMarketplaceTerms",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MarketplaceOrdering",
     "Version": "1.0.2",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "Set-AzMarketplaceTerms",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.MarketplaceOrdering",
     "Version": "1.0.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Media.1.1.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Media.1.1.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Sync-AzMediaServiceStorageKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -47,6 +48,7 @@
   {
     "Command": "Set-AzMediaServiceKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -90,6 +92,7 @@
   {
     "Command": "Get-AzMediaServiceKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -117,6 +120,7 @@
   {
     "Command": "Get-AzMediaServiceNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -140,6 +144,7 @@
   {
     "Command": "New-AzMediaServiceStorageConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -176,6 +181,7 @@
   {
     "Command": "Remove-AzMediaService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -219,6 +225,7 @@
   {
     "Command": "New-AzMediaService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -276,6 +283,7 @@
   {
     "Command": "Get-AzMediaService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -303,6 +311,7 @@
   {
     "Command": "Set-AzMediaService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -350,6 +359,7 @@
   {
     "Command": "Sync-AzMediaServiceStorageKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [
@@ -395,6 +405,7 @@
   {
     "Command": "Get-AzMediaServiceKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Media",
     "Version": "1.1.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Monitor.2.3.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Monitor.2.3.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzMetricDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -34,6 +35,7 @@
   {
     "Command": "Get-AzMetric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -100,6 +102,7 @@
   {
     "Command": "Remove-AzLogProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -136,6 +139,7 @@
   {
     "Command": "Get-AzLogProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -156,6 +160,7 @@
   {
     "Command": "Add-AzLogProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -208,6 +213,7 @@
   {
     "Command": "Get-AzActivityLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -266,6 +272,7 @@
   {
     "Command": "New-AzDiagnosticSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -318,6 +325,7 @@
   {
     "Command": "New-AzDiagnosticDetailSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -362,6 +370,7 @@
   {
     "Command": "Set-AzDiagnosticSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -458,6 +467,7 @@
   {
     "Command": "Get-AzDiagnosticSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -482,6 +492,7 @@
   {
     "Command": "Get-AzDiagnosticSettingCategory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -506,6 +517,7 @@
   {
     "Command": "Remove-AzDiagnosticSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -542,6 +554,7 @@
   {
     "Command": "New-AzAutoscaleNotification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -574,6 +587,7 @@
   {
     "Command": "New-AzAutoscaleProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -642,6 +656,7 @@
   {
     "Command": "New-AzAutoscaleRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -706,6 +721,7 @@
   {
     "Command": "Add-AzAutoscaleSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -770,6 +786,7 @@
   {
     "Command": "Get-AzAutoscaleHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -810,6 +827,7 @@
   {
     "Command": "Get-AzAutoscaleSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -840,6 +858,7 @@
   {
     "Command": "New-AzAutoscaleWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -864,6 +883,7 @@
   {
     "Command": "Remove-AzAutoscaleSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -902,6 +922,7 @@
   {
     "Command": "Add-AzMetricAlertRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -980,6 +1001,7 @@
   {
     "Command": "Add-AzWebtestAlertRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1054,6 +1076,7 @@
   {
     "Command": "Get-AzAlertHistory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1094,6 +1117,7 @@
   {
     "Command": "Get-AzAlertRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1128,6 +1152,7 @@
   {
     "Command": "New-AzAlertRuleEmail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1152,6 +1177,7 @@
   {
     "Command": "New-AzAlertRuleWebhook",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1176,6 +1202,7 @@
   {
     "Command": "Remove-AzAlertRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1214,6 +1241,7 @@
   {
     "Command": "Set-AzActivityLogAlert",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1286,6 +1314,7 @@
   {
     "Command": "Get-AzActivityLogAlert",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1310,6 +1339,7 @@
   {
     "Command": "New-AzActionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1334,6 +1364,7 @@
   {
     "Command": "New-AzActivityLogAlertCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1358,6 +1389,7 @@
   {
     "Command": "Enable-AzActivityLogAlert",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1402,6 +1434,7 @@
   {
     "Command": "Disable-AzActivityLogAlert",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1446,6 +1479,7 @@
   {
     "Command": "Remove-AzActivityLogAlert",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1490,6 +1524,7 @@
   {
     "Command": "New-AzActionGroupReceiver",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1658,6 +1693,7 @@
   {
     "Command": "Set-AzActionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1718,6 +1754,7 @@
   {
     "Command": "Get-AzActionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1742,6 +1779,7 @@
   {
     "Command": "Remove-AzActionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1786,6 +1824,7 @@
   {
     "Command": "New-AzMetricFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1814,6 +1853,7 @@
   {
     "Command": "Add-AzMetricAlertRuleV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1908,6 +1948,7 @@
   {
     "Command": "Get-AzMetricAlertRuleV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1938,6 +1979,7 @@
   {
     "Command": "New-AzMetricAlertRuleV2DimensionSelection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -1966,6 +2008,7 @@
   {
     "Command": "New-AzMetricAlertRuleV2Criteria",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2058,6 +2101,7 @@
   {
     "Command": "Remove-AzMetricAlertRuleV2",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2114,6 +2158,7 @@
   {
     "Command": "New-AzScheduledQueryRuleSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2146,6 +2191,7 @@
   {
     "Command": "New-AzScheduledQueryRuleSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2170,6 +2216,7 @@
   {
     "Command": "New-AzScheduledQueryRuleTriggerCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2198,6 +2245,7 @@
   {
     "Command": "New-AzScheduledQueryRuleLogMetricTrigger",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2230,6 +2278,7 @@
   {
     "Command": "New-AzScheduledQueryRuleAznsActionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2258,6 +2307,7 @@
   {
     "Command": "New-AzScheduledQueryRuleAlertingAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2290,6 +2340,7 @@
   {
     "Command": "New-AzScheduledQueryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2358,6 +2409,7 @@
   {
     "Command": "Get-AzScheduledQueryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2386,6 +2438,7 @@
   {
     "Command": "Set-AzScheduledQueryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2462,6 +2515,7 @@
   {
     "Command": "Update-AzScheduledQueryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2510,6 +2564,7 @@
   {
     "Command": "Remove-AzScheduledQueryRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2558,6 +2613,7 @@
   {
     "Command": "New-AzInsightsPrivateLinkScope",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2602,6 +2658,7 @@
   {
     "Command": "Get-AzInsightsPrivateLinkScope",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2630,6 +2687,7 @@
   {
     "Command": "Update-AzInsightsPrivateLinkScope",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2678,6 +2736,7 @@
   {
     "Command": "Remove-AzInsightsPrivateLinkScope",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2722,6 +2781,7 @@
   {
     "Command": "New-AzInsightsPrivateLinkScopedResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2770,6 +2830,7 @@
   {
     "Command": "Get-AzInsightsPrivateLinkScopedResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2806,6 +2867,7 @@
   {
     "Command": "Remove-AzInsightsPrivateLinkScopedResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [
@@ -2854,6 +2916,7 @@
   {
     "Command": "Get-AzLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Monitor",
     "Version": "2.3.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Network.4.3.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Network.4.3.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzApplicationGatewayAuthenticationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -42,6 +43,7 @@
   {
     "Command": "Get-AzApplicationGatewayAuthenticationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -66,6 +68,7 @@
   {
     "Command": "New-AzApplicationGatewayAuthenticationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -102,6 +105,7 @@
   {
     "Command": "Remove-AzApplicationGatewayAuthenticationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -138,6 +142,7 @@
   {
     "Command": "Set-AzApplicationGatewayAuthenticationCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -178,6 +183,7 @@
   {
     "Command": "Get-AzApplicationGatewayAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -198,6 +204,7 @@
   {
     "Command": "New-AzApplicationGatewayAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -234,6 +241,7 @@
   {
     "Command": "Remove-AzApplicationGatewayAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -270,6 +278,7 @@
   {
     "Command": "Set-AzApplicationGatewayAutoscaleConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -310,6 +319,7 @@
   {
     "Command": "Get-AzApplicationGatewayAvailableWafRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -326,6 +336,7 @@
   {
     "Command": "Get-AzApplicationGatewayAvailableSslOption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -342,6 +353,7 @@
   {
     "Command": "Add-AzApplicationGatewayBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -386,6 +398,7 @@
   {
     "Command": "Get-AzApplicationGatewayBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -410,6 +423,7 @@
   {
     "Command": "New-AzApplicationGatewayBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -450,6 +464,7 @@
   {
     "Command": "Remove-AzApplicationGatewayBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -486,6 +501,7 @@
   {
     "Command": "Set-AzApplicationGatewayBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -530,6 +546,7 @@
   {
     "Command": "Add-AzApplicationGatewayBackendHttpSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -606,6 +623,7 @@
   {
     "Command": "Get-AzApplicationGatewayBackendHttpSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -630,6 +648,7 @@
   {
     "Command": "New-AzApplicationGatewayBackendHttpSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -702,6 +721,7 @@
   {
     "Command": "Remove-AzApplicationGatewayBackendHttpSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -726,6 +746,7 @@
   {
     "Command": "Set-AzApplicationGatewayBackendHttpSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -802,6 +823,7 @@
   {
     "Command": "Get-AzApplicationGatewayConnectionDraining",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -822,6 +844,7 @@
   {
     "Command": "New-AzApplicationGatewayConnectionDraining",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -846,6 +869,7 @@
   {
     "Command": "Remove-AzApplicationGatewayConnectionDraining",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -866,6 +890,7 @@
   {
     "Command": "Set-AzApplicationGatewayConnectionDraining",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -894,6 +919,7 @@
   {
     "Command": "Get-AzApplicationGatewayWebApplicationFirewallConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -914,6 +940,7 @@
   {
     "Command": "New-AzApplicationGatewayWebApplicationFirewallConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -980,6 +1007,7 @@
   {
     "Command": "Set-AzApplicationGatewayWebApplicationFirewallConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1050,6 +1078,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallDisabledRuleGroupConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1074,6 +1103,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallExclusionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1102,6 +1132,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1138,6 +1169,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallCustomRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1174,6 +1206,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallMatchVariable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1198,6 +1231,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1264,6 +1298,7 @@
   {
     "Command": "Get-AzApplicationGatewayFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1290,6 +1325,7 @@
   {
     "Command": "Remove-AzApplicationGatewayFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1348,6 +1384,7 @@
   {
     "Command": "Set-AzApplicationGatewayFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1408,6 +1445,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicyExclusion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1436,6 +1474,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicyManagedRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1460,6 +1499,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicyManagedRuleOverride",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1484,6 +1524,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicyManagedRuleGroupOverride",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1508,6 +1549,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicyManagedRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1536,6 +1578,7 @@
   {
     "Command": "New-AzApplicationGatewayFirewallPolicySetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1572,6 +1615,7 @@
   {
     "Command": "Add-AzApplicationGatewayFrontendIPConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1624,6 +1668,7 @@
   {
     "Command": "Get-AzApplicationGatewayFrontendIPConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1648,6 +1693,7 @@
   {
     "Command": "New-AzApplicationGatewayFrontendIPConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1696,6 +1742,7 @@
   {
     "Command": "Remove-AzApplicationGatewayFrontendIPConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1720,6 +1767,7 @@
   {
     "Command": "Set-AzApplicationGatewayFrontendIPConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1772,6 +1820,7 @@
   {
     "Command": "Add-AzApplicationGatewayFrontendPort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1800,6 +1849,7 @@
   {
     "Command": "Get-AzApplicationGatewayFrontendPort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1824,6 +1874,7 @@
   {
     "Command": "New-AzApplicationGatewayFrontendPort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1848,6 +1899,7 @@
   {
     "Command": "Remove-AzApplicationGatewayFrontendPort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1872,6 +1924,7 @@
   {
     "Command": "Set-AzApplicationGatewayFrontendPort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1900,6 +1953,7 @@
   {
     "Command": "Get-AzApplicationGatewayIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1920,6 +1974,7 @@
   {
     "Command": "New-AzApplicationGatewayIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1954,6 +2009,7 @@
   {
     "Command": "Remove-AzApplicationGatewayIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -1986,6 +2042,7 @@
   {
     "Command": "Set-AzApplicationGatewayIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2024,6 +2081,7 @@
   {
     "Command": "Add-AzApplicationGatewayIPConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2056,6 +2114,7 @@
   {
     "Command": "Get-AzApplicationGatewayIPConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2080,6 +2139,7 @@
   {
     "Command": "New-AzApplicationGatewayIPConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2108,6 +2168,7 @@
   {
     "Command": "Remove-AzApplicationGatewayIPConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2132,6 +2193,7 @@
   {
     "Command": "Set-AzApplicationGatewayIPConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2164,6 +2226,7 @@
   {
     "Command": "Get-AzApplicationGatewayBackendHealth",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2198,6 +2261,7 @@
   {
     "Command": "Get-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2224,6 +2288,7 @@
   {
     "Command": "Add-AzApplicationGatewayHttpListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2308,6 +2373,7 @@
   {
     "Command": "Get-AzApplicationGatewayHttpListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2332,6 +2398,7 @@
   {
     "Command": "New-AzApplicationGatewayHttpListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2412,6 +2479,7 @@
   {
     "Command": "Remove-AzApplicationGatewayHttpListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2436,6 +2504,7 @@
   {
     "Command": "Set-AzApplicationGatewayHttpListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2520,6 +2589,7 @@
   {
     "Command": "New-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2696,6 +2766,7 @@
   {
     "Command": "Add-AzApplicationGatewaySslProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2732,6 +2803,7 @@
   {
     "Command": "Get-AzApplicationGatewaySslProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2756,6 +2828,7 @@
   {
     "Command": "New-AzApplicationGatewaySslProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2788,6 +2861,7 @@
   {
     "Command": "Remove-AzApplicationGatewaySslProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2812,6 +2886,7 @@
   {
     "Command": "Set-AzApplicationGatewaySslProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2848,6 +2923,7 @@
   {
     "Command": "New-AzApplicationGatewayCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2872,6 +2948,7 @@
   {
     "Command": "Add-AzApplicationGatewayCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2900,6 +2977,7 @@
   {
     "Command": "Get-AzApplicationGatewayCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2924,6 +3002,7 @@
   {
     "Command": "Remove-AzApplicationGatewayCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2948,6 +3027,7 @@
   {
     "Command": "Set-AzApplicationGatewayCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -2976,6 +3056,7 @@
   {
     "Command": "Add-AzApplicationGatewayHttpListenerCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3004,6 +3085,7 @@
   {
     "Command": "Get-AzApplicationGatewayHttpListenerCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3028,6 +3110,7 @@
   {
     "Command": "Remove-AzApplicationGatewayHttpListenerCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3052,6 +3135,7 @@
   {
     "Command": "Set-AzApplicationGatewayHttpListenerCustomError",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3080,6 +3164,7 @@
   {
     "Command": "New-AzApplicationGatewayPathRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3144,6 +3229,7 @@
   {
     "Command": "Add-AzApplicationGatewayProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3208,6 +3294,7 @@
   {
     "Command": "Get-AzApplicationGatewayProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3232,6 +3319,7 @@
   {
     "Command": "New-AzApplicationGatewayProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3292,6 +3380,7 @@
   {
     "Command": "Remove-AzApplicationGatewayProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3316,6 +3405,7 @@
   {
     "Command": "Set-AzApplicationGatewayProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3380,6 +3470,7 @@
   {
     "Command": "New-AzApplicationGatewayProbeHealthResponseMatch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3404,6 +3495,7 @@
   {
     "Command": "Remove-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3450,6 +3542,7 @@
   {
     "Command": "Add-AzApplicationGatewayRequestRoutingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3463,10 +3556,6 @@
       },
       {
         "Name": "RuleType",
-        "Aliases": null
-      },
-      {
-        "Name": "Priority",
         "Aliases": null
       },
       {
@@ -3530,6 +3619,7 @@
   {
     "Command": "Get-AzApplicationGatewayRequestRoutingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3554,6 +3644,7 @@
   {
     "Command": "New-AzApplicationGatewayRequestRoutingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3563,10 +3654,6 @@
       },
       {
         "Name": "RuleType",
-        "Aliases": null
-      },
-      {
-        "Name": "Priority",
         "Aliases": null
       },
       {
@@ -3630,6 +3717,7 @@
   {
     "Command": "Remove-AzApplicationGatewayRequestRoutingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3654,6 +3742,7 @@
   {
     "Command": "Set-AzApplicationGatewayRequestRoutingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3667,10 +3756,6 @@
       },
       {
         "Name": "RuleType",
-        "Aliases": null
-      },
-      {
-        "Name": "Priority",
         "Aliases": null
       },
       {
@@ -3734,6 +3819,7 @@
   {
     "Command": "Add-AzApplicationGatewayRewriteRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3762,6 +3848,7 @@
   {
     "Command": "Get-AzApplicationGatewayRewriteRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3786,6 +3873,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3810,6 +3898,7 @@
   {
     "Command": "Remove-AzApplicationGatewayRewriteRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3834,6 +3923,7 @@
   {
     "Command": "Set-AzApplicationGatewayRewriteRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3862,6 +3952,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3894,6 +3985,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRuleActionSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3922,6 +4014,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRuleHeaderConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3946,6 +4039,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRuleUrlConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -3986,6 +4080,7 @@
   {
     "Command": "Get-AzApplicationGatewayAvailableServerVariableAndHeader",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4014,6 +4109,7 @@
   {
     "Command": "New-AzApplicationGatewayRewriteRuleCondition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4046,6 +4142,7 @@
   {
     "Command": "Add-AzApplicationGatewayRedirectConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4094,6 +4191,7 @@
   {
     "Command": "Get-AzApplicationGatewayRedirectConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4118,6 +4216,7 @@
   {
     "Command": "New-AzApplicationGatewayRedirectConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4162,6 +4261,7 @@
   {
     "Command": "Remove-AzApplicationGatewayRedirectConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4186,6 +4286,7 @@
   {
     "Command": "Set-AzApplicationGatewayRedirectConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4234,6 +4335,7 @@
   {
     "Command": "Set-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4258,6 +4360,7 @@
   {
     "Command": "Get-AzApplicationGatewaySku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4278,6 +4381,7 @@
   {
     "Command": "New-AzApplicationGatewaySku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4306,6 +4410,7 @@
   {
     "Command": "Set-AzApplicationGatewaySku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4338,6 +4443,7 @@
   {
     "Command": "Add-AzApplicationGatewaySslCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4374,6 +4480,7 @@
   {
     "Command": "Get-AzApplicationGatewaySslCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4398,6 +4505,7 @@
   {
     "Command": "New-AzApplicationGatewaySslCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4430,6 +4538,7 @@
   {
     "Command": "Remove-AzApplicationGatewaySslCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4454,6 +4563,7 @@
   {
     "Command": "Set-AzApplicationGatewaySslCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4490,6 +4600,7 @@
   {
     "Command": "Get-AzApplicationGatewaySslPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4510,6 +4621,7 @@
   {
     "Command": "New-AzApplicationGatewaySslPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4558,6 +4670,7 @@
   {
     "Command": "Remove-AzApplicationGatewaySslPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4594,6 +4707,7 @@
   {
     "Command": "Set-AzApplicationGatewaySslPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4646,6 +4760,7 @@
   {
     "Command": "Get-AzApplicationGatewaySslProfilePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4666,6 +4781,7 @@
   {
     "Command": "Remove-AzApplicationGatewaySslProfilePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4686,6 +4802,7 @@
   {
     "Command": "Set-AzApplicationGatewaySslProfilePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4726,6 +4843,7 @@
   {
     "Command": "Get-AzApplicationGatewayClientAuthConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4746,6 +4864,7 @@
   {
     "Command": "New-AzApplicationGatewayClientAuthConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4766,6 +4885,7 @@
   {
     "Command": "Remove-AzApplicationGatewayClientAuthConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4786,6 +4906,7 @@
   {
     "Command": "Set-AzApplicationGatewayClientAuthConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4810,6 +4931,7 @@
   {
     "Command": "Get-AzApplicationGatewaySslPredefinedPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4830,6 +4952,7 @@
   {
     "Command": "Start-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4850,6 +4973,7 @@
   {
     "Command": "Stop-AzApplicationGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4874,6 +4998,7 @@
   {
     "Command": "Add-AzApplicationGatewayTrustedRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4914,6 +5039,7 @@
   {
     "Command": "Get-AzApplicationGatewayTrustedRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4938,6 +5064,7 @@
   {
     "Command": "New-AzApplicationGatewayTrustedRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -4974,6 +5101,7 @@
   {
     "Command": "Remove-AzApplicationGatewayTrustedRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5010,6 +5138,7 @@
   {
     "Command": "Set-AzApplicationGatewayTrustedRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5050,6 +5179,7 @@
   {
     "Command": "Add-AzApplicationGatewayTrustedClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5078,6 +5208,7 @@
   {
     "Command": "Get-AzApplicationGatewayTrustedClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5102,6 +5233,7 @@
   {
     "Command": "New-AzApplicationGatewayTrustedClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5126,6 +5258,7 @@
   {
     "Command": "Remove-AzApplicationGatewayTrustedClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5150,6 +5283,7 @@
   {
     "Command": "Set-AzApplicationGatewayTrustedClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5178,6 +5312,7 @@
   {
     "Command": "Add-AzApplicationGatewayUrlPathMapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5238,6 +5373,7 @@
   {
     "Command": "Get-AzApplicationGatewayUrlPathMapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5262,6 +5398,7 @@
   {
     "Command": "New-AzApplicationGatewayUrlPathMapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5318,6 +5455,7 @@
   {
     "Command": "Remove-AzApplicationGatewayUrlPathMapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5342,6 +5480,7 @@
   {
     "Command": "Set-AzApplicationGatewayUrlPathMapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5402,6 +5541,7 @@
   {
     "Command": "New-AzApplicationGatewayPrivateLinkConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5426,6 +5566,7 @@
   {
     "Command": "Add-AzApplicationGatewayPrivateLinkConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5454,6 +5595,7 @@
   {
     "Command": "Set-AzApplicationGatewayPrivateLinkConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5482,6 +5624,7 @@
   {
     "Command": "Get-AzApplicationGatewayPrivateLinkConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5506,6 +5649,7 @@
   {
     "Command": "Remove-AzApplicationGatewayPrivateLinkConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5530,6 +5674,7 @@
   {
     "Command": "New-AzApplicationGatewayPrivateLinkIpConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5566,6 +5711,7 @@
   {
     "Command": "Add-AzExpressRouteCircuitAuthorization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5590,6 +5736,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitAuthorization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5614,6 +5761,7 @@
   {
     "Command": "New-AzExpressRouteCircuitAuthorization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5634,6 +5782,7 @@
   {
     "Command": "Remove-AzExpressRouteCircuitAuthorization",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5658,6 +5807,7 @@
   {
     "Command": "Move-AzExpressRouteCircuit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5716,6 +5866,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitARPTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5751,6 +5902,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5786,6 +5938,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitRouteTableSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5821,6 +5974,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitStat",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5852,6 +6006,7 @@
   {
     "Command": "Add-AzLoadBalancerInboundNatPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5924,6 +6079,7 @@
   {
     "Command": "Get-AzLoadBalancerInboundNatPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -5948,6 +6104,7 @@
   {
     "Command": "New-AzLoadBalancerInboundNatPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6016,6 +6173,7 @@
   {
     "Command": "Remove-AzLoadBalancerInboundNatPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6052,6 +6210,7 @@
   {
     "Command": "Set-AzLoadBalancerInboundNatPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6124,6 +6283,7 @@
   {
     "Command": "Get-AzExpressRouteCircuit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6150,6 +6310,7 @@
   {
     "Command": "New-AzExpressRouteCircuit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6244,6 +6405,7 @@
   {
     "Command": "Add-AzExpressRouteCircuitPeeringConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6320,6 +6482,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitPeeringConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6344,6 +6507,7 @@
   {
     "Command": "New-AzExpressRouteCircuitPeeringConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6416,6 +6580,7 @@
   {
     "Command": "Remove-AzExpressRouteCircuitPeeringConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6444,6 +6609,7 @@
   {
     "Command": "Set-AzExpressRouteCircuitPeeringConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6520,6 +6686,7 @@
   {
     "Command": "Remove-AzExpressRouteCircuit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6570,6 +6737,7 @@
   {
     "Command": "Set-AzExpressRouteCircuit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6594,6 +6762,7 @@
   {
     "Command": "Get-AzExpressRoutePort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6624,6 +6793,7 @@
   {
     "Command": "New-AzExpressRoutePort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6702,6 +6872,7 @@
   {
     "Command": "Get-AzExpressRoutePortLinkConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6730,6 +6901,7 @@
   {
     "Command": "Remove-AzExpressRoutePort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6788,6 +6960,7 @@
   {
     "Command": "Set-AzExpressRoutePort",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6826,6 +6999,7 @@
   {
     "Command": "Get-AzExpressRoutePortsLocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6846,6 +7020,7 @@
   {
     "Command": "Get-AzExpressRoutePortIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6866,6 +7041,7 @@
   {
     "Command": "New-AzExpressRoutePortIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6888,6 +7064,7 @@
   {
     "Command": "Remove-AzExpressRoutePortIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6908,6 +7085,7 @@
   {
     "Command": "Set-AzExpressRoutePortIdentity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6934,6 +7112,7 @@
   {
     "Command": "Get-AzEffectiveNetworkSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6958,6 +7137,7 @@
   {
     "Command": "Get-AzEffectiveRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -6986,6 +7166,7 @@
   {
     "Command": "Add-AzNetworkInterfaceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7070,6 +7251,7 @@
   {
     "Command": "Get-AzNetworkInterfaceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7094,6 +7276,7 @@
   {
     "Command": "New-AzNetworkInterfaceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7174,6 +7357,7 @@
   {
     "Command": "Remove-AzNetworkInterfaceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7198,6 +7382,7 @@
   {
     "Command": "Set-AzNetworkInterfaceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7282,6 +7467,7 @@
   {
     "Command": "New-AzNetworkWatcher",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7328,6 +7514,7 @@
   {
     "Command": "Get-AzNetworkWatcher",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7358,6 +7545,7 @@
   {
     "Command": "Remove-AzNetworkWatcher",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7412,6 +7600,7 @@
   {
     "Command": "New-AzNetworkWatcherPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7498,6 +7687,7 @@
   {
     "Command": "Get-AzNetworkWatcherPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7540,6 +7730,7 @@
   {
     "Command": "Stop-AzNetworkWatcherPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7598,6 +7789,7 @@
   {
     "Command": "Remove-AzNetworkWatcherPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7656,6 +7848,7 @@
   {
     "Command": "New-AzPacketCaptureFilterConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7692,6 +7885,7 @@
   {
     "Command": "Get-AzNetworkWatcherTopology",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7730,6 +7924,7 @@
   {
     "Command": "Get-AzNetworkWatcherSecurityGroupView",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7772,6 +7967,7 @@
   {
     "Command": "Test-AzNetworkWatcherIPFlow",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7842,6 +8038,7 @@
   {
     "Command": "Get-AzNetworkWatcherNextHop",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7896,6 +8093,7 @@
   {
     "Command": "Start-AzNetworkWatcherResourceTroubleshooting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7942,6 +8140,7 @@
   {
     "Command": "Get-AzNetworkWatcherTroubleshootingResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -7980,6 +8179,7 @@
   {
     "Command": "Get-AzNetworkWatcherFlowLogStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8022,6 +8222,7 @@
   {
     "Command": "Set-AzNetworkWatcherConfigFlowLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8126,6 +8327,7 @@
   {
     "Command": "New-AzNetworkWatcherFlowLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8224,6 +8426,7 @@
   {
     "Command": "Set-AzNetworkWatcherFlowLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8330,6 +8533,7 @@
   {
     "Command": "Get-AzNetworkWatcherFlowLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8372,6 +8576,7 @@
   {
     "Command": "Remove-AzNetworkWatcherFlowLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8438,6 +8643,7 @@
   {
     "Command": "Test-AzNetworkWatcherConnectivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8500,6 +8706,7 @@
   {
     "Command": "Get-AzNetworkWatcherReachabilityReport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8571,6 +8778,7 @@
   {
     "Command": "Get-AzNetworkWatcherReachabilityProvidersList",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8630,6 +8838,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorEndpointObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8706,6 +8915,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8772,6 +8982,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorEndpointScopeItemObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8804,6 +9015,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorTestConfigurationObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8858,6 +9070,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorTestGroupObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8906,6 +9119,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorOutputObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -8942,6 +9156,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitorProtocolConfigurationObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9002,6 +9217,7 @@
   {
     "Command": "New-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9108,6 +9324,7 @@
   {
     "Command": "Set-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9214,6 +9431,7 @@
   {
     "Command": "Start-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9280,6 +9498,7 @@
   {
     "Command": "Stop-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9346,6 +9565,7 @@
   {
     "Command": "Remove-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9412,6 +9632,7 @@
   {
     "Command": "Get-AzNetworkWatcherConnectionMonitor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9454,6 +9675,7 @@
   {
     "Command": "Get-AzNetworkWatcherConnectionMonitorReport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9504,6 +9726,7 @@
   {
     "Command": "Invoke-AzNetworkWatcherNetworkConfigurationDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9558,6 +9781,7 @@
   {
     "Command": "New-AzNetworkWatcherNetworkConfigurationDiagnosticProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9594,6 +9818,7 @@
   {
     "Command": "Get-AzExpressRouteServiceProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9610,6 +9835,7 @@
   {
     "Command": "Test-AzPrivateIPAddressAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9642,6 +9868,7 @@
   {
     "Command": "Get-AzPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9688,6 +9915,7 @@
   {
     "Command": "New-AzPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9782,6 +10010,7 @@
   {
     "Command": "Remove-AzPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9832,6 +10061,7 @@
   {
     "Command": "Set-AzPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9856,6 +10086,7 @@
   {
     "Command": "Get-AzPublicIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9886,6 +10117,7 @@
   {
     "Command": "New-AzPublicIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -9968,6 +10200,7 @@
   {
     "Command": "Remove-AzPublicIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10026,6 +10259,7 @@
   {
     "Command": "Set-AzPublicIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10062,6 +10296,7 @@
   {
     "Command": "Get-AzRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10092,6 +10327,7 @@
   {
     "Command": "New-AzRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10154,6 +10390,7 @@
   {
     "Command": "Remove-AzRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10204,6 +10441,7 @@
   {
     "Command": "Add-AzRouteConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10252,6 +10490,7 @@
   {
     "Command": "Get-AzRouteConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10276,6 +10515,7 @@
   {
     "Command": "New-AzRouteConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10320,6 +10560,7 @@
   {
     "Command": "Remove-AzRouteConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10356,6 +10597,7 @@
   {
     "Command": "Set-AzRouteConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10404,6 +10646,7 @@
   {
     "Command": "Set-AzRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10440,6 +10683,7 @@
   {
     "Command": "New-AzRadiusServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10468,6 +10712,7 @@
   {
     "Command": "Set-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10592,6 +10837,7 @@
   {
     "Command": "Get-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10618,6 +10864,7 @@
   {
     "Command": "New-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10768,6 +11015,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayVpnclientConnectionHealth",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10822,6 +11070,7 @@
   {
     "Command": "Get-AzVpnClientRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10852,6 +11101,7 @@
   {
     "Command": "Get-AzVpnClientRevokedCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10882,6 +11132,7 @@
   {
     "Command": "Add-AzVpnClientRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10916,6 +11167,7 @@
   {
     "Command": "Add-AzVpnClientRevokedCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10950,6 +11202,7 @@
   {
     "Command": "New-AzVpnClientRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10974,6 +11227,7 @@
   {
     "Command": "New-AzVpnClientRevokedCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -10998,6 +11252,7 @@
   {
     "Command": "Resize-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11022,6 +11277,7 @@
   {
     "Command": "Remove-AzVpnClientRevokedCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11056,6 +11312,7 @@
   {
     "Command": "Remove-AzVpnClientRootCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11090,6 +11347,7 @@
   {
     "Command": "Get-AzVpnClientPackage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11118,6 +11376,7 @@
   {
     "Command": "New-AzVpnClientConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11172,6 +11431,7 @@
   {
     "Command": "Get-AzVpnClientConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11210,6 +11470,7 @@
   {
     "Command": "New-AzVirtualNetworkGatewayIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11250,6 +11511,7 @@
   {
     "Command": "Add-AzVirtualNetworkGatewayIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11306,6 +11568,7 @@
   {
     "Command": "Remove-AzVirtualNetworkGatewayIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11342,6 +11605,7 @@
   {
     "Command": "Remove-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11392,6 +11656,7 @@
   {
     "Command": "Reset-AzVirtualNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11420,6 +11685,7 @@
   {
     "Command": "Set-AzVirtualNetworkGatewayDefaultSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11444,6 +11710,7 @@
   {
     "Command": "Remove-AzVirtualNetworkGatewayDefaultSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11464,6 +11731,7 @@
   {
     "Command": "New-AzVpnClientIpsecPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11512,6 +11780,7 @@
   {
     "Command": "New-AzVpnClientIpsecParameter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11560,6 +11829,7 @@
   {
     "Command": "Set-AzVpnClientIpsecParameter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11608,6 +11878,7 @@
   {
     "Command": "Get-AzVpnClientIpsecParameter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11634,6 +11905,7 @@
   {
     "Command": "Remove-AzVpnClientIpsecParameter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11678,6 +11950,7 @@
   {
     "Command": "Remove-AzLocalNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11728,6 +12001,7 @@
   {
     "Command": "Get-AzLocalNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11754,6 +12028,7 @@
   {
     "Command": "New-AzLocalNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11832,6 +12107,7 @@
   {
     "Command": "Set-AzLocalNetworkGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11872,6 +12148,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11898,6 +12175,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayConnectionSharedKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -11924,6 +12202,7 @@
   {
     "Command": "New-AzVirtualNetworkGatewayConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12046,6 +12325,7 @@
   {
     "Command": "Remove-AzVirtualNetworkGatewayConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12092,6 +12372,7 @@
   {
     "Command": "Reset-AzVirtualNetworkGatewayConnectionSharedKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12138,6 +12419,7 @@
   {
     "Command": "Set-AzVirtualNetworkGatewayConnectionSharedKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12184,6 +12466,7 @@
   {
     "Command": "Set-AzVirtualNetworkGatewayConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12252,6 +12535,7 @@
   {
     "Command": "New-AzIpsecPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12300,6 +12584,7 @@
   {
     "Command": "New-AzIpsecTrafficSelectorPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12336,6 +12621,7 @@
   {
     "Command": "Get-AzLoadBalancerBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12372,6 +12658,7 @@
   {
     "Command": "New-AzLoadBalancerBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12420,6 +12707,7 @@
   {
     "Command": "Remove-AzLoadBalancerBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12476,6 +12764,7 @@
   {
     "Command": "Set-AzLoadBalancerBackendAddressPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12540,6 +12829,7 @@
   {
     "Command": "New-AzLoadBalancerBackendAddressConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12584,6 +12874,7 @@
   {
     "Command": "Get-AzLoadBalancerBackendAddressPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12608,6 +12899,7 @@
   {
     "Command": "Add-AzLoadBalancerBackendAddressPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12644,6 +12936,7 @@
   {
     "Command": "New-AzLoadBalancerBackendAddressPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12676,6 +12969,7 @@
   {
     "Command": "Remove-AzLoadBalancerBackendAddressPoolConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12712,6 +13006,7 @@
   {
     "Command": "Set-AzLoadBalancerFrontendIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12784,6 +13079,7 @@
   {
     "Command": "Get-AzLoadBalancerFrontendIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12808,6 +13104,7 @@
   {
     "Command": "Add-AzLoadBalancerFrontendIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12880,6 +13177,7 @@
   {
     "Command": "New-AzLoadBalancerFrontendIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12948,6 +13246,7 @@
   {
     "Command": "Remove-AzLoadBalancerFrontendIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -12984,6 +13283,7 @@
   {
     "Command": "Get-AzLoadBalancer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13014,6 +13314,7 @@
   {
     "Command": "Set-AzLoadBalancerInboundNatRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13082,6 +13383,7 @@
   {
     "Command": "Get-AzLoadBalancerInboundNatRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13106,6 +13408,7 @@
   {
     "Command": "Add-AzLoadBalancerInboundNatRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13174,6 +13477,7 @@
   {
     "Command": "New-AzLoadBalancerInboundNatRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13238,6 +13542,7 @@
   {
     "Command": "Remove-AzLoadBalancerInboundNatRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13274,6 +13579,7 @@
   {
     "Command": "Get-AzBgpServiceCommunity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13290,6 +13596,7 @@
   {
     "Command": "Get-AzRouteFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13320,6 +13627,7 @@
   {
     "Command": "Set-AzRouteFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13360,6 +13668,7 @@
   {
     "Command": "Remove-AzRouteFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13406,6 +13715,7 @@
   {
     "Command": "New-AzRouteFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13464,6 +13774,7 @@
   {
     "Command": "Get-AzRouteFilterRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13488,6 +13799,7 @@
   {
     "Command": "Add-AzRouteFilterRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13540,6 +13852,7 @@
   {
     "Command": "Remove-AzRouteFilterRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13580,6 +13893,7 @@
   {
     "Command": "Set-AzRouteFilterRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13632,6 +13946,7 @@
   {
     "Command": "New-AzRouteFilterRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13680,6 +13995,7 @@
   {
     "Command": "Set-AzLoadBalancerRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13772,6 +14088,7 @@
   {
     "Command": "Get-AzLoadBalancerRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13796,6 +14113,7 @@
   {
     "Command": "Add-AzLoadBalancerRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13888,6 +14206,7 @@
   {
     "Command": "New-AzLoadBalancerRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -13976,6 +14295,7 @@
   {
     "Command": "Remove-AzLoadBalancerRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14012,6 +14332,7 @@
   {
     "Command": "New-AzLoadBalancer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14102,6 +14423,7 @@
   {
     "Command": "Set-AzLoadBalancerProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14158,6 +14480,7 @@
   {
     "Command": "Get-AzLoadBalancerProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14182,6 +14505,7 @@
   {
     "Command": "Add-AzLoadBalancerProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14238,6 +14562,7 @@
   {
     "Command": "New-AzLoadBalancerProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14290,6 +14615,7 @@
   {
     "Command": "Remove-AzLoadBalancerProbeConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14326,6 +14652,7 @@
   {
     "Command": "Remove-AzLoadBalancer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14376,6 +14703,7 @@
   {
     "Command": "Set-AzLoadBalancer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14412,6 +14740,7 @@
   {
     "Command": "Add-AzLoadBalancerOutboundRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14476,6 +14805,7 @@
   {
     "Command": "Get-AzLoadBalancerOutboundRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14500,6 +14830,7 @@
   {
     "Command": "New-AzLoadBalancerOutboundRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14560,6 +14891,7 @@
   {
     "Command": "Set-AzLoadBalancerOutboundRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14624,6 +14956,7 @@
   {
     "Command": "Remove-AzLoadBalancerOutboundRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14660,6 +14993,7 @@
   {
     "Command": "Remove-AzNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14710,6 +15044,7 @@
   {
     "Command": "Get-AzNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14750,6 +15085,7 @@
   {
     "Command": "New-AzNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14888,6 +15224,7 @@
   {
     "Command": "Set-AzNetworkInterface",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14912,6 +15249,7 @@
   {
     "Command": "Get-AzNetworkSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -14942,6 +15280,7 @@
   {
     "Command": "New-AzNetworkSecurityRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15014,6 +15353,7 @@
   {
     "Command": "Get-AzNetworkSecurityRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15042,6 +15382,7 @@
   {
     "Command": "Remove-AzNetworkSecurityRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15066,6 +15407,7 @@
   {
     "Command": "Set-AzNetworkSecurityRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15142,6 +15484,7 @@
   {
     "Command": "Add-AzNetworkSecurityRuleConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15218,6 +15561,7 @@
   {
     "Command": "New-AzNetworkSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15276,6 +15620,7 @@
   {
     "Command": "Remove-AzNetworkSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15326,6 +15671,7 @@
   {
     "Command": "Set-AzNetworkSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15362,6 +15708,7 @@
   {
     "Command": "Test-AzDnsAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15388,6 +15735,7 @@
   {
     "Command": "Add-AzVirtualNetworkPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15436,6 +15784,7 @@
   {
     "Command": "Get-AzVirtualNetworkPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15464,6 +15813,7 @@
   {
     "Command": "Remove-AzVirtualNetworkPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15516,6 +15866,7 @@
   {
     "Command": "Set-AzVirtualNetworkPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15540,6 +15891,7 @@
   {
     "Command": "Remove-AzVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15590,6 +15942,7 @@
   {
     "Command": "Set-AzVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15614,6 +15967,7 @@
   {
     "Command": "Remove-AzVirtualNetworkSubnetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15638,6 +15992,7 @@
   {
     "Command": "Set-AzVirtualNetworkSubnetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15718,6 +16073,7 @@
   {
     "Command": "Get-AzVirtualNetworkSubnetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15746,6 +16102,7 @@
   {
     "Command": "Add-AzVirtualNetworkSubnetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15826,6 +16183,7 @@
   {
     "Command": "New-AzVirtualNetworkSubnetConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15902,6 +16260,7 @@
   {
     "Command": "New-AzDelegation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15926,6 +16285,7 @@
   {
     "Command": "Add-AzDelegation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15954,6 +16314,7 @@
   {
     "Command": "Get-AzDelegation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -15978,6 +16339,7 @@
   {
     "Command": "Remove-AzDelegation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16002,6 +16364,7 @@
   {
     "Command": "Get-AzAvailableServiceDelegation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16022,6 +16385,7 @@
   {
     "Command": "Get-AzVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16052,6 +16416,7 @@
   {
     "Command": "New-AzVirtualNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16134,6 +16499,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayBgpPeerStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16168,6 +16534,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayAdvertisedRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16202,6 +16569,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayLearnedRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16232,6 +16600,7 @@
   {
     "Command": "Get-AzNetworkUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16252,6 +16621,7 @@
   {
     "Command": "Get-AzVirtualNetworkUsageList",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16276,6 +16646,7 @@
   {
     "Command": "Get-AzVirtualNetworkAvailableEndpointService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16296,6 +16667,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewaySupportedVpnDevice",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16322,6 +16694,7 @@
   {
     "Command": "Get-AzVirtualNetworkGatewayConnectionVpnDeviceConfigScript",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16372,6 +16745,7 @@
   {
     "Command": "New-AzApplicationSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16426,6 +16800,7 @@
   {
     "Command": "Remove-AzApplicationSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16476,6 +16851,7 @@
   {
     "Command": "Get-AzApplicationSecurityGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16502,6 +16878,7 @@
   {
     "Command": "New-AzPublicIpTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16538,6 +16915,7 @@
   {
     "Command": "New-AzDdosProtectionPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16588,6 +16966,7 @@
   {
     "Command": "Get-AzDdosProtectionPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16614,6 +16993,7 @@
   {
     "Command": "Remove-AzDdosProtectionPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16656,6 +17036,7 @@
   {
     "Command": "New-AzNetworkWatcherProtocolConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16688,6 +17069,7 @@
   {
     "Command": "Add-AzExpressRouteCircuitConnectionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16740,6 +17122,7 @@
   {
     "Command": "Set-AzExpressRouteCircuitConnectionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16792,6 +17175,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitConnectionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16816,6 +17200,7 @@
   {
     "Command": "Remove-AzExpressRouteCircuitConnectionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16856,6 +17241,7 @@
   {
     "Command": "New-AzServiceEndpointPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16904,6 +17290,7 @@
   {
     "Command": "Remove-AzServiceEndpointPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16956,6 +17343,7 @@
   {
     "Command": "Get-AzServiceEndpointPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -16996,6 +17384,7 @@
   {
     "Command": "New-AzServiceEndpointPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17040,6 +17429,7 @@
   {
     "Command": "Remove-AzServiceEndpointPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17084,6 +17474,7 @@
   {
     "Command": "Get-AzServiceEndpointPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17120,6 +17511,7 @@
   {
     "Command": "Set-AzServiceEndpointPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17168,6 +17560,7 @@
   {
     "Command": "Add-AzServiceEndpointPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17216,6 +17609,7 @@
   {
     "Command": "Set-AzServiceEndpointPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17248,6 +17642,7 @@
   {
     "Command": "New-AzVirtualWan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17311,6 +17706,7 @@
   {
     "Command": "Update-AzVirtualWan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17386,6 +17782,7 @@
   {
     "Command": "Get-AzVirtualWan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17412,6 +17809,7 @@
   {
     "Command": "Remove-AzVirtualWan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17471,6 +17869,7 @@
   {
     "Command": "Get-AzVirtualWanVpnServerConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17509,6 +17908,7 @@
   {
     "Command": "Get-AzVirtualWanVpnServerConfigurationVpnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17559,6 +17959,7 @@
   {
     "Command": "New-AzVirtualHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17634,6 +18035,7 @@
   {
     "Command": "Get-AzVirtualHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17661,6 +18063,7 @@
   {
     "Command": "Update-AzVirtualHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17736,6 +18139,7 @@
   {
     "Command": "Remove-AzVirtualHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17799,6 +18203,7 @@
   {
     "Command": "Set-AzVirtualHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17863,6 +18268,7 @@
   {
     "Command": "New-AzVirtualHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17887,6 +18293,7 @@
   {
     "Command": "Add-AzVirtualHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17919,6 +18326,7 @@
   {
     "Command": "New-AzVirtualHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17939,6 +18347,7 @@
   {
     "Command": "Add-AzVirtualHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -17967,6 +18376,7 @@
   {
     "Command": "Get-AzVirtualHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18016,6 +18426,7 @@
   {
     "Command": "Remove-AzVirtualHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18094,6 +18505,7 @@
   {
     "Command": "New-AzVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18161,6 +18573,7 @@
   {
     "Command": "Reset-AzVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18215,6 +18628,7 @@
   {
     "Command": "Get-AzVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18242,6 +18656,7 @@
   {
     "Command": "Update-AzVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18312,6 +18727,7 @@
   {
     "Command": "Remove-AzVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18371,6 +18787,7 @@
   {
     "Command": "Start-AzVpnGatewayPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18429,6 +18846,7 @@
   {
     "Command": "Stop-AzVpnGatewayPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18487,6 +18905,7 @@
   {
     "Command": "Start-AzVpnConnectionPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18556,6 +18975,7 @@
   {
     "Command": "Stop-AzVpnConnectionPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18624,6 +19044,7 @@
   {
     "Command": "New-AzVpnSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18731,6 +19152,7 @@
   {
     "Command": "New-AzVpnSiteLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18775,6 +19197,7 @@
   {
     "Command": "New-AzVpnSiteLinkConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18833,6 +19256,7 @@
   {
     "Command": "Get-AzVpnSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18860,6 +19284,7 @@
   {
     "Command": "Update-AzVpnSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -18975,6 +19400,7 @@
   {
     "Command": "Remove-AzVpnSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19034,6 +19460,7 @@
   {
     "Command": "New-AzVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19146,6 +19573,7 @@
   {
     "Command": "Get-AzVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19194,6 +19622,7 @@
   {
     "Command": "Update-AzVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19292,6 +19721,7 @@
   {
     "Command": "Remove-AzVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19358,6 +19788,7 @@
   {
     "Command": "New-AzVirtualHubVnetConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19442,6 +19873,7 @@
   {
     "Command": "Get-AzVirtualHubVnetConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19490,6 +19922,7 @@
   {
     "Command": "Remove-AzVirtualHubVnetConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19560,6 +19993,7 @@
   {
     "Command": "Update-AzVirtualHubVnetConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19630,6 +20064,7 @@
   {
     "Command": "Get-AzVpnServerConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19657,6 +20092,7 @@
   {
     "Command": "New-AzVpnServerConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19760,6 +20196,7 @@
   {
     "Command": "Remove-AzVpnServerConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19819,6 +20256,7 @@
   {
     "Command": "Update-AzVpnServerConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19930,6 +20368,7 @@
   {
     "Command": "Get-AzP2sVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -19957,6 +20396,7 @@
   {
     "Command": "Disconnect-AzP2sVpnGatewayVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20018,6 +20458,7 @@
   {
     "Command": "Get-AzP2sVpnGatewayConnectionHealth",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20054,6 +20495,7 @@
   {
     "Command": "Get-AzP2sVpnGatewayDetailedConnectionHealth",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20098,6 +20540,7 @@
   {
     "Command": "Get-AzP2sVpnGatewayVpnProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20138,6 +20581,7 @@
   {
     "Command": "New-AzP2sVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20225,6 +20669,7 @@
   {
     "Command": "Remove-AzP2sVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20284,6 +20729,7 @@
   {
     "Command": "Update-AzP2sVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20374,6 +20820,7 @@
   {
     "Command": "Reset-AzP2sVpnGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20428,6 +20875,7 @@
   {
     "Command": "Get-AzVirtualWanVpnConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20491,6 +20939,7 @@
   {
     "Command": "Get-AzFirewall",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20517,6 +20966,7 @@
   {
     "Command": "Set-AzFirewall",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20553,6 +21003,7 @@
   {
     "Command": "New-AzFirewall",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20689,6 +21140,7 @@
   {
     "Command": "Remove-AzFirewall",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20739,6 +21191,7 @@
   {
     "Command": "New-AzFirewallApplicationRuleCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20783,6 +21236,7 @@
   {
     "Command": "New-AzFirewallApplicationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20839,6 +21293,7 @@
   {
     "Command": "New-AzFirewallNatRuleCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20879,6 +21334,7 @@
   {
     "Command": "New-AzFirewallNatRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20947,6 +21403,7 @@
   {
     "Command": "New-AzFirewallNetworkRuleCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -20991,6 +21448,7 @@
   {
     "Command": "New-AzFirewallNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21055,6 +21513,7 @@
   {
     "Command": "New-AzFirewallThreatIntelWhitelist",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21079,6 +21538,7 @@
   {
     "Command": "New-AzFirewallHubPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21103,6 +21563,7 @@
   {
     "Command": "New-AzFirewallHubIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21127,6 +21588,7 @@
   {
     "Command": "New-AzFirewallPublicIpAddress",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21147,6 +21609,7 @@
   {
     "Command": "Get-AzFirewallFqdnTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21163,6 +21626,7 @@
   {
     "Command": "Get-AzNetworkProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21197,6 +21661,7 @@
   {
     "Command": "New-AzNetworkProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21257,6 +21722,7 @@
   {
     "Command": "Remove-AzNetworkProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21315,6 +21781,7 @@
   {
     "Command": "Set-AzNetworkProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21351,6 +21818,7 @@
   {
     "Command": "New-AzContainerNicConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21389,6 +21857,7 @@
   {
     "Command": "New-AzContainerNicConfigIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21429,6 +21898,7 @@
   {
     "Command": "Add-AzNetworkInterfaceTapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21473,6 +21943,7 @@
   {
     "Command": "Get-AzNetworkInterfaceTapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21517,6 +21988,7 @@
   {
     "Command": "Set-AzNetworkInterfaceTapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21557,6 +22029,7 @@
   {
     "Command": "Remove-AzNetworkInterfaceTapConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21613,6 +22086,7 @@
   {
     "Command": "Get-AzVirtualNetworkTap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21653,6 +22127,7 @@
   {
     "Command": "New-AzVirtualNetworkTap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21725,6 +22200,7 @@
   {
     "Command": "Remove-AzVirtualNetworkTap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21781,6 +22257,7 @@
   {
     "Command": "Set-AzVirtualNetworkTap",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21817,6 +22294,7 @@
   {
     "Command": "Get-AzExpressRouteGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21850,6 +22328,7 @@
   {
     "Command": "New-AzExpressRouteGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21917,6 +22396,7 @@
   {
     "Command": "Remove-AzExpressRouteGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -21976,6 +22456,7 @@
   {
     "Command": "Set-AzExpressRouteGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22042,6 +22523,7 @@
   {
     "Command": "Get-AzExpressRouteConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22085,6 +22567,7 @@
   {
     "Command": "New-AzExpressRouteConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22164,6 +22647,7 @@
   {
     "Command": "Remove-AzExpressRouteConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22227,6 +22711,7 @@
   {
     "Command": "Set-AzExpressRouteConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22302,6 +22787,7 @@
   {
     "Command": "Get-AzExpressRouteCrossConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22326,6 +22812,7 @@
   {
     "Command": "Set-AzExpressRouteCrossConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22386,6 +22873,7 @@
   {
     "Command": "Add-AzExpressRouteCrossConnectionPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22466,6 +22954,7 @@
   {
     "Command": "Get-AzExpressRouteCrossConnectionPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22490,6 +22979,7 @@
   {
     "Command": "Remove-AzExpressRouteCrossConnectionPeering",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22534,6 +23024,7 @@
   {
     "Command": "Get-AzExpressRouteCrossConnectionArpTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22573,6 +23064,7 @@
   {
     "Command": "Get-AzExpressRouteCrossConnectionRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22612,6 +23104,7 @@
   {
     "Command": "Get-AzExpressRouteCrossConnectionRouteTableSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22651,6 +23144,7 @@
   {
     "Command": "Get-AzNatGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22681,6 +23175,7 @@
   {
     "Command": "New-AzNatGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22755,6 +23250,7 @@
   {
     "Command": "Remove-AzNatGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22815,6 +23311,7 @@
   {
     "Command": "Set-AzNatGateway",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22879,6 +23376,7 @@
   {
     "Command": "Get-AzNetworkServiceTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22899,6 +23397,7 @@
   {
     "Command": "New-AzPrivateEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22965,6 +23464,7 @@
   {
     "Command": "Get-AzPrivateEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -22995,6 +23495,7 @@
   {
     "Command": "Remove-AzPrivateEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23045,6 +23546,7 @@
   {
     "Command": "New-AzPrivateLinkServiceConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23081,6 +23583,7 @@
   {
     "Command": "New-AzPrivateDnsZoneConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23105,6 +23608,7 @@
   {
     "Command": "Remove-AzPrivateDnsZoneGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23159,6 +23663,7 @@
   {
     "Command": "Get-AzPrivateDnsZoneGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23189,6 +23694,7 @@
   {
     "Command": "New-AzPrivateDnsZoneGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23243,6 +23749,7 @@
   {
     "Command": "Set-AzPrivateDnsZoneGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23293,6 +23800,7 @@
   {
     "Command": "New-AzPrivateLinkService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23367,6 +23875,7 @@
   {
     "Command": "Get-AzPrivateLinkService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23397,6 +23906,7 @@
   {
     "Command": "Remove-AzPrivateLinkService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23447,6 +23957,7 @@
   {
     "Command": "New-AzPrivateLinkServiceIpConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23487,6 +23998,7 @@
   {
     "Command": "Set-AzPrivateEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23511,6 +24023,7 @@
   {
     "Command": "Set-AzPrivateLinkService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23535,6 +24048,7 @@
   {
     "Command": "Set-AzPrivateEndpointConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23581,6 +24095,7 @@
   {
     "Command": "Get-AzPrivateEndpointConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23627,6 +24142,7 @@
   {
     "Command": "Remove-AzPrivateEndpointConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23693,6 +24209,7 @@
   {
     "Command": "Get-AzAutoApprovedPrivateLinkService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23717,6 +24234,7 @@
   {
     "Command": "Test-AzPrivateLinkServiceVisibility",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23745,6 +24263,7 @@
   {
     "Command": "Approve-AzPrivateEndpointConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23787,6 +24306,7 @@
   {
     "Command": "Deny-AzPrivateEndpointConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23829,6 +24349,7 @@
   {
     "Command": "Get-AzAvailablePrivateEndpointType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23853,6 +24374,7 @@
   {
     "Command": "Get-AzAvailableServiceAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23873,6 +24395,7 @@
   {
     "Command": "Get-AzPrivateLinkResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23905,6 +24428,7 @@
   {
     "Command": "New-AzBastion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -23996,6 +24520,7 @@
   {
     "Command": "Get-AzBastion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24039,6 +24564,7 @@
   {
     "Command": "Remove-AzBastion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24099,6 +24625,7 @@
   {
     "Command": "Start-AzVirtualNetworkGatewayPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24157,6 +24684,7 @@
   {
     "Command": "Stop-AzVirtualNetworkGatewayPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24215,6 +24743,7 @@
   {
     "Command": "Start-AzVirtualNetworkGatewayConnectionPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24273,6 +24802,7 @@
   {
     "Command": "Stop-AzVirtualNetworkGatewayConnectionPacketCapture",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24330,6 +24860,7 @@
   {
     "Command": "Disconnect-AzVirtualNetworkGatewayVpnConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24392,6 +24923,7 @@
   {
     "Command": "New-AzFirewallPolicyNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24444,6 +24976,7 @@
   {
     "Command": "New-AzFirewallPolicyNatRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24500,6 +25033,7 @@
   {
     "Command": "New-AzFirewallPolicyApplicationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24544,6 +25078,7 @@
   {
     "Command": "New-AzFirewallPolicyNatRuleCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24576,6 +25111,7 @@
   {
     "Command": "New-AzFirewallPolicyFilterRuleCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24608,6 +25144,7 @@
   {
     "Command": "New-AzFirewallPolicyRuleCollectionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24660,6 +25197,7 @@
   {
     "Command": "Set-AzFirewallPolicyRuleCollectionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24722,6 +25260,7 @@
   {
     "Command": "Get-AzFirewallPolicyRuleCollectionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24760,6 +25299,7 @@
   {
     "Command": "Remove-AzFirewallPolicyRuleCollectionGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24826,6 +25366,7 @@
   {
     "Command": "New-AzFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24896,6 +25437,7 @@
   {
     "Command": "Get-AzFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -24926,6 +25468,7 @@
   {
     "Command": "Set-AzFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25000,6 +25543,7 @@
   {
     "Command": "Remove-AzFirewallPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25058,6 +25602,7 @@
   {
     "Command": "New-AzFirewallPolicyThreatIntelWhitelist",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25082,6 +25627,7 @@
   {
     "Command": "New-AzFirewallPolicyDnsSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25118,6 +25664,7 @@
   {
     "Command": "New-AzVirtualRouter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25176,6 +25723,7 @@
   {
     "Command": "Remove-AzVirtualRouter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25234,6 +25782,7 @@
   {
     "Command": "Get-AzVirtualRouter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25264,6 +25813,7 @@
   {
     "Command": "Update-AzVirtualRouter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25310,6 +25860,7 @@
   {
     "Command": "Add-AzVirtualRouterPeer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25368,6 +25919,7 @@
   {
     "Command": "Update-AzVirtualRouterPeer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25434,6 +25986,7 @@
   {
     "Command": "Remove-AzVirtualRouterPeer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25492,6 +26045,7 @@
   {
     "Command": "Get-AzVirtualRouterPeer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25526,6 +26080,7 @@
   {
     "Command": "Get-AzVirtualRouterPeerAdvertisedRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25564,6 +26119,7 @@
   {
     "Command": "Get-AzVirtualRouterPeerLearnedRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25602,6 +26158,7 @@
   {
     "Command": "New-AzIpGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25660,6 +26217,7 @@
   {
     "Command": "Remove-AzIpGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25718,6 +26276,7 @@
   {
     "Command": "Get-AzIpGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25748,6 +26307,7 @@
   {
     "Command": "Set-AzIpGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25784,6 +26344,7 @@
   {
     "Command": "New-AzIpConfigurationBgpPeeringAddressObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25820,6 +26381,7 @@
   {
     "Command": "New-AzIpAllocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25898,6 +26460,7 @@
   {
     "Command": "Get-AzIpAllocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25928,6 +26491,7 @@
   {
     "Command": "Remove-AzIpAllocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -25986,6 +26550,7 @@
   {
     "Command": "Set-AzIpAllocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26034,6 +26599,7 @@
   {
     "Command": "New-AzSecurityPartnerProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26104,6 +26670,7 @@
   {
     "Command": "Remove-AzSecurityPartnerProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26162,6 +26729,7 @@
   {
     "Command": "Get-AzSecurityPartnerProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26192,6 +26760,7 @@
   {
     "Command": "Set-AzSecurityPartnerProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26228,6 +26797,7 @@
   {
     "Command": "Reset-AzHubRouter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26284,6 +26854,7 @@
   {
     "Command": "New-AzVHubRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26320,6 +26891,7 @@
   {
     "Command": "New-AzStaticRoute",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26348,6 +26920,7 @@
   {
     "Command": "New-AzRoutingConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26380,6 +26953,7 @@
   {
     "Command": "New-AzVHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26453,6 +27027,7 @@
   {
     "Command": "Get-AzVHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26502,6 +27077,7 @@
   {
     "Command": "Update-AzVHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26582,6 +27158,7 @@
   {
     "Command": "Remove-AzVHubRouteTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26662,6 +27239,7 @@
   {
     "Command": "Get-AzNetworkVirtualAppliance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26692,6 +27270,7 @@
   {
     "Command": "New-AzNetworkVirtualAppliance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26778,6 +27357,7 @@
   {
     "Command": "Remove-AzNetworkVirtualAppliance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26836,6 +27416,7 @@
   {
     "Command": "Update-AzNetworkVirtualAppliance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26894,6 +27475,7 @@
   {
     "Command": "Get-AzVirtualApplianceSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26928,6 +27510,7 @@
   {
     "Command": "New-AzVirtualApplianceSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -26994,6 +27577,7 @@
   {
     "Command": "Remove-AzVirtualApplianceSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27056,6 +27640,7 @@
   {
     "Command": "Update-AzVirtualApplianceSite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27118,6 +27703,7 @@
   {
     "Command": "New-AzOffice365PolicyProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27146,6 +27732,7 @@
   {
     "Command": "Get-AzNetworkVirtualApplianceSku",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27166,6 +27753,7 @@
   {
     "Command": "New-AzVirtualApplianceSkuProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27196,6 +27784,7 @@
   {
     "Command": "New-AzCustomIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27254,6 +27843,7 @@
   {
     "Command": "Update-AzCustomIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27314,6 +27904,7 @@
   {
     "Command": "Get-AzCustomIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27344,6 +27935,7 @@
   {
     "Command": "Remove-AzCustomIpPrefix",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27402,6 +27994,7 @@
   {
     "Command": "New-AzExpressRoutePortLOA",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27454,6 +28047,7 @@
   {
     "Command": "New-AzO365PolicyProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27482,6 +28076,7 @@
   {
     "Command": "List-AzApplicationGatewayAvailableWafRuleSets",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27498,6 +28093,7 @@
   {
     "Command": "List-AzApplicationGatewayAvailableSslOptions",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27514,6 +28110,7 @@
   {
     "Command": "List-AzApplicationGatewaySslPredefinedPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27534,6 +28131,7 @@
   {
     "Command": "List-AzApplicationGatewayAvailableServerVariableAndHeader",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27562,6 +28160,7 @@
   {
     "Command": "Add-AzApplicationGatewayBackendHttpSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27638,6 +28237,7 @@
   {
     "Command": "Get-AzApplicationGatewayBackendHttpSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27662,6 +28262,7 @@
   {
     "Command": "New-AzApplicationGatewayBackendHttpSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27734,6 +28335,7 @@
   {
     "Command": "Remove-AzApplicationGatewayBackendHttpSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27758,6 +28360,7 @@
   {
     "Command": "Set-AzApplicationGatewayBackendHttpSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27834,6 +28437,7 @@
   {
     "Command": "Get-AzExpressRouteCircuitStats",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27865,6 +28469,7 @@
   {
     "Command": "Get-AzApplicationGatewayAvailableWafRuleSets",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27881,6 +28486,7 @@
   {
     "Command": "Get-AzApplicationGatewayAvailableSslOptions",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27897,6 +28503,7 @@
   {
     "Command": "Get-AzInterfaceEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [
@@ -27927,6 +28534,7 @@
   {
     "Command": "New-AzFirewallThreatIntelWhitelistObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Network",
     "Version": "4.3.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.NotificationHubs.1.1.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.NotificationHubs.1.1.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzNotificationHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "Get-AzNotificationHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -62,6 +64,7 @@
   {
     "Command": "Get-AzNotificationHubListKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -94,6 +97,7 @@
   {
     "Command": "Get-AzNotificationHubPNSCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -122,6 +126,7 @@
   {
     "Command": "New-AzNotificationHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -166,6 +171,7 @@
   {
     "Command": "New-AzNotificationHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -214,6 +220,7 @@
   {
     "Command": "New-AzNotificationHubKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -266,6 +273,7 @@
   {
     "Command": "Remove-AzNotificationHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -310,6 +318,7 @@
   {
     "Command": "Remove-AzNotificationHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -358,6 +367,7 @@
   {
     "Command": "Set-AzNotificationHub",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -406,6 +416,7 @@
   {
     "Command": "Set-AzNotificationHubAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -458,6 +469,7 @@
   {
     "Command": "Get-AzNotificationHubsNamespaceAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -486,6 +498,7 @@
   {
     "Command": "Get-AzNotificationHubsNamespaceListKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -514,6 +527,7 @@
   {
     "Command": "New-AzNotificationHubsNamespaceAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -558,6 +572,7 @@
   {
     "Command": "New-AzNotificationHubsNamespaceKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -606,6 +621,7 @@
   {
     "Command": "Remove-AzNotificationHubsNamespaceAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -650,6 +666,7 @@
   {
     "Command": "Set-AzNotificationHubsNamespaceAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -698,6 +715,7 @@
   {
     "Command": "Get-AzNotificationHubsNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -722,6 +740,7 @@
   {
     "Command": "New-AzNotificationHubsNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -770,6 +789,7 @@
   {
     "Command": "Remove-AzNotificationHubsNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -810,6 +830,7 @@
   {
     "Command": "Set-AzNotificationHubsNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -870,6 +891,7 @@
   {
     "Command": "Get-AzNotificationHubAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -902,6 +924,7 @@
   {
     "Command": "Get-AzNotificationHubListKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -934,6 +957,7 @@
   {
     "Command": "Get-AzNotificationHubPNSCredentials",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -962,6 +986,7 @@
   {
     "Command": "Get-AzNotificationHubsNamespaceAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -990,6 +1015,7 @@
   {
     "Command": "Get-AzNotificationHubsNamespaceListKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1018,6 +1044,7 @@
   {
     "Command": "New-AzNotificationHubAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1066,6 +1093,7 @@
   {
     "Command": "New-AzNotificationHubsNamespaceAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1110,6 +1138,7 @@
   {
     "Command": "Remove-AzNotificationHubAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1158,6 +1187,7 @@
   {
     "Command": "Remove-AzNotificationHubsNamespaceAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1202,6 +1232,7 @@
   {
     "Command": "Set-AzNotificationHubAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [
@@ -1254,6 +1285,7 @@
   {
     "Command": "Set-AzNotificationHubsNamespaceAuthorizationRules",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.NotificationHubs",
     "Version": "1.1.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.OperationalInsights.2.3.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.OperationalInsights.2.3.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzOperationalInsightsAzureActivityLogDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -58,6 +59,7 @@
   {
     "Command": "New-AzOperationalInsightsCustomLogDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -110,6 +112,7 @@
   {
     "Command": "Disable-AzOperationalInsightsLinuxCustomLogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -150,6 +153,7 @@
   {
     "Command": "Disable-AzOperationalInsightsIISLogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -190,6 +194,7 @@
   {
     "Command": "Enable-AzOperationalInsightsLinuxCustomLogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -230,6 +235,7 @@
   {
     "Command": "Enable-AzOperationalInsightsIISLogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -270,6 +276,7 @@
   {
     "Command": "Enable-AzOperationalInsightsLinuxSyslogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -310,6 +317,7 @@
   {
     "Command": "Enable-AzOperationalInsightsLinuxPerformanceCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -350,6 +358,7 @@
   {
     "Command": "Disable-AzOperationalInsightsLinuxPerformanceCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -390,6 +399,7 @@
   {
     "Command": "New-AzOperationalInsightsWindowsPerformanceCounterDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -458,6 +468,7 @@
   {
     "Command": "New-AzOperationalInsightsLinuxPerformanceObjectDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -522,6 +533,7 @@
   {
     "Command": "New-AzOperationalInsightsLinuxSyslogDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -606,6 +618,7 @@
   {
     "Command": "New-AzOperationalInsightsApplicationInsightsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -666,6 +679,7 @@
   {
     "Command": "Disable-AzOperationalInsightsLinuxSyslogCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -706,6 +720,7 @@
   {
     "Command": "New-AzOperationalInsightsWindowsEventDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -770,6 +785,7 @@
   {
     "Command": "Get-AzOperationalInsightsSavedSearch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -800,6 +816,7 @@
   {
     "Command": "Get-AzOperationalInsightsSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -826,6 +843,7 @@
   {
     "Command": "New-AzOperationalInsightsComputerGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -888,6 +906,7 @@
   {
     "Command": "New-AzOperationalInsightsSavedSearch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -964,6 +983,7 @@
   {
     "Command": "Set-AzOperationalInsightsSavedSearch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1028,6 +1048,7 @@
   {
     "Command": "Remove-AzOperationalInsightsSavedSearch",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1070,6 +1091,7 @@
   {
     "Command": "Get-AzOperationalInsightsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1106,6 +1128,7 @@
   {
     "Command": "Remove-AzOperationalInsightsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1154,6 +1177,7 @@
   {
     "Command": "Set-AzOperationalInsightsDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1174,6 +1198,7 @@
   {
     "Command": "Get-AzOperationalInsightsStorageInsight",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1206,6 +1231,7 @@
   {
     "Command": "Set-AzOperationalInsightsStorageInsight",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1250,6 +1276,7 @@
   {
     "Command": "New-AzOperationalInsightsStorageInsight",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1314,6 +1341,7 @@
   {
     "Command": "Remove-AzOperationalInsightsStorageInsight",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1362,6 +1390,7 @@
   {
     "Command": "Set-AzOperationalInsightsIntelligencePack",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1396,6 +1425,7 @@
   {
     "Command": "Get-AzOperationalInsightsIntelligencePack",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1422,6 +1452,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspaceManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1446,6 +1477,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspaceUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1470,6 +1502,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspaceSharedKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1494,6 +1527,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1518,6 +1552,7 @@
   {
     "Command": "New-AzOperationalInsightsWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1582,6 +1617,7 @@
   {
     "Command": "Remove-AzOperationalInsightsWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1626,6 +1662,7 @@
   {
     "Command": "Set-AzOperationalInsightsWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1674,6 +1711,7 @@
   {
     "Command": "Invoke-AzOperationalInsightsQuery",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1722,6 +1760,7 @@
   {
     "Command": "New-AzOperationalInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1770,6 +1809,7 @@
   {
     "Command": "Get-AzOperationalInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1798,6 +1838,7 @@
   {
     "Command": "Set-AzOperationalInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1846,6 +1887,7 @@
   {
     "Command": "Remove-AzOperationalInsightsLinkedStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1890,6 +1932,7 @@
   {
     "Command": "New-AzOperationalInsightsCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1950,6 +1993,7 @@
   {
     "Command": "Get-AzOperationalInsightsCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -1974,6 +2018,7 @@
   {
     "Command": "Update-AzOperationalInsightsCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2038,6 +2083,7 @@
   {
     "Command": "Remove-AzOperationalInsightsCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2078,6 +2124,7 @@
   {
     "Command": "Get-AzOperationalInsightsLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2106,6 +2153,7 @@
   {
     "Command": "Set-AzOperationalInsightsLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2162,6 +2210,7 @@
   {
     "Command": "Remove-AzOperationalInsightsLinkedService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2206,6 +2255,7 @@
   {
     "Command": "Get-AzOperationalInsightsDeletedWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2226,6 +2276,7 @@
   {
     "Command": "Restore-AzOperationalInsightsWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2270,6 +2321,7 @@
   {
     "Command": "New-AzOperationalInsightsAzureAuditDataSource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2326,6 +2378,7 @@
   {
     "Command": "Get-AzOperationalInsightsIntelligencePacks",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2352,6 +2405,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspaceManagementGroups",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [
@@ -2376,6 +2430,7 @@
   {
     "Command": "Get-AzOperationalInsightsWorkspaceSharedKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.OperationalInsights",
     "Version": "2.3.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PolicyInsights.1.3.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PolicyInsights.1.3.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzPolicyEvent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -74,6 +75,7 @@
   {
     "Command": "Get-AzPolicyState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -154,6 +156,7 @@
   {
     "Command": "Get-AzPolicyStateSummary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -214,6 +217,7 @@
   {
     "Command": "Get-AzPolicyRemediation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -264,6 +268,7 @@
   {
     "Command": "Remove-AzPolicyRemediation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -330,6 +335,7 @@
   {
     "Command": "Start-AzPolicyRemediation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -400,6 +406,7 @@
   {
     "Command": "Stop-AzPolicyRemediation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -462,6 +469,7 @@
   {
     "Command": "Get-AzPolicyMetadata",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [
@@ -486,6 +494,7 @@
   {
     "Command": "Start-AzPolicyComplianceScan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PolicyInsights",
     "Version": "1.3.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PowerBIEmbedded.1.1.2.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PowerBIEmbedded.1.1.2.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Remove-AzPowerBIWorkspaceCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -41,6 +42,7 @@
   {
     "Command": "Get-AzPowerBIWorkspaceCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -68,6 +70,7 @@
   {
     "Command": "Get-AzPowerBIWorkspaceCollectionAccessKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -95,6 +98,7 @@
   {
     "Command": "Get-AzPowerBIWorkspace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -122,6 +126,7 @@
   {
     "Command": "New-AzPowerBIWorkspaceCollection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -165,6 +170,7 @@
   {
     "Command": "Reset-AzPowerBIWorkspaceCollectionAccessKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -212,6 +218,7 @@
   {
     "Command": "Resume-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -260,6 +267,7 @@
   {
     "Command": "Suspend-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -308,6 +316,7 @@
   {
     "Command": "Get-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -336,6 +345,7 @@
   {
     "Command": "Remove-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -384,6 +394,7 @@
   {
     "Command": "Update-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -444,6 +455,7 @@
   {
     "Command": "Test-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -464,6 +476,7 @@
   {
     "Command": "New-AzPowerBIEmbeddedCapacity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -516,6 +529,7 @@
   {
     "Command": "Get-AzPowerBIWorkspaceCollectionAccessKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [
@@ -543,6 +557,7 @@
   {
     "Command": "Reset-AzPowerBIWorkspaceCollectionAccessKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PowerBIEmbedded",
     "Version": "1.1.2",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PrivateDns.1.0.3.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.PrivateDns.1.0.3.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzPrivateDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -26,6 +27,7 @@
   {
     "Command": "Remove-AzPrivateDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -78,6 +80,7 @@
   {
     "Command": "Set-AzPrivateDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -130,6 +133,7 @@
   {
     "Command": "New-AzPrivateDnsZone",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -170,6 +174,7 @@
   {
     "Command": "Get-AzPrivateDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -210,6 +215,7 @@
   {
     "Command": "Remove-AzPrivateDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -274,6 +280,7 @@
   {
     "Command": "Set-AzPrivateDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -310,6 +317,7 @@
   {
     "Command": "New-AzPrivateDnsRecordSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -380,6 +388,7 @@
   {
     "Command": "Add-AzPrivateDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -444,6 +453,7 @@
   {
     "Command": "Remove-AzPrivateDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -508,6 +518,7 @@
   {
     "Command": "New-AzPrivateDnsRecordConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -568,6 +579,7 @@
   {
     "Command": "Get-AzPrivateDnsVirtualNetworkLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -596,6 +608,7 @@
   {
     "Command": "Remove-AzPrivateDnsVirtualNetworkLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -652,6 +665,7 @@
   {
     "Command": "Set-AzPrivateDnsVirtualNetworkLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [
@@ -712,6 +726,7 @@
   {
     "Command": "New-AzPrivateDnsVirtualNetworkLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.PrivateDns",
     "Version": "1.0.3",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.RecoveryServices.3.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.RecoveryServices.3.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -22,6 +23,7 @@
   {
     "Command": "Get-AzRecoveryServicesVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -58,6 +60,7 @@
   {
     "Command": "Get-AzRecoveryServicesVaultSettingsFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -102,6 +105,7 @@
   {
     "Command": "New-AzRecoveryServicesVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -146,6 +150,7 @@
   {
     "Command": "Remove-AzRecoveryServicesVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -178,6 +183,7 @@
   {
     "Command": "Add-AzRecoveryServicesAsrReplicationProtectedItemDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -220,6 +226,7 @@
   {
     "Command": "Edit-AzRecoveryServicesAsrRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -278,6 +285,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrAlertSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -294,6 +302,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrEvent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -346,6 +355,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -370,6 +380,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -410,6 +421,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -438,6 +450,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -466,6 +479,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -490,6 +504,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -518,6 +533,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrProtectionContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -546,6 +562,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -570,6 +587,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -598,6 +616,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrRecoveryPoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -622,6 +641,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -654,6 +674,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -682,6 +703,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrStorageClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -710,6 +732,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -734,6 +757,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrVaultContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -750,6 +774,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -778,6 +803,7 @@
   {
     "Command": "Import-AzRecoveryServicesAsrVaultSettingsFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -810,6 +836,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -854,6 +881,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrInMageAzureV2DiskInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -898,6 +926,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -958,6 +987,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1068,6 +1098,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1112,6 +1143,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrProtectionContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1150,6 +1182,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1194,6 +1227,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1262,6 +1296,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1426,6 +1461,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1466,6 +1502,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1514,6 +1551,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrAzureToAzureDiskReplicationConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1602,6 +1640,7 @@
   {
     "Command": "New-AzRecoveryServicesAsrVMNicConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1718,6 +1757,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1756,6 +1796,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1790,6 +1831,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1824,6 +1866,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrProtectionContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1858,6 +1901,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1896,6 +1940,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1934,6 +1979,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -1976,6 +2022,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrReplicationProtectedItemDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2018,6 +2065,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2056,6 +2104,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2090,6 +2139,7 @@
   {
     "Command": "Remove-AzRecoveryServicesAsrvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2136,6 +2186,7 @@
   {
     "Command": "Restart-AzRecoveryServicesAsrJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2174,6 +2225,7 @@
   {
     "Command": "Resume-AzRecoveryServicesAsrJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2218,6 +2270,7 @@
   {
     "Command": "Set-AzRecoveryServicesAsrAlertSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2266,6 +2319,7 @@
   {
     "Command": "Set-AzRecoveryServicesAsrReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2408,6 +2462,7 @@
   {
     "Command": "Set-AzRecoveryServicesAsrVaultContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2440,6 +2495,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrApplyRecoveryPoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2484,6 +2540,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrCommitFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2520,6 +2577,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrPlannedFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2580,6 +2638,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrResynchronizeReplicationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2616,6 +2675,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrSwitchProcessServerJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2664,6 +2724,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrTestFailoverCleanupJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2708,6 +2769,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrTestFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2776,6 +2838,7 @@
   {
     "Command": "Start-AzRecoveryServicesAsrUnplannedFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2838,6 +2901,7 @@
   {
     "Command": "Stop-AzRecoveryServicesAsrJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2876,6 +2940,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrMobilityService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2912,6 +2977,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -2954,6 +3020,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3062,6 +3129,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3112,6 +3180,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrProtectionDirection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3244,6 +3313,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3282,6 +3352,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3316,6 +3387,7 @@
   {
     "Command": "Update-AzRecoveryServicesAsrvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3362,6 +3434,7 @@
   {
     "Command": "Set-AzRecoveryServicesBackupProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3398,6 +3471,7 @@
   {
     "Command": "Set-AzRecoveryServicesVaultContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3418,6 +3492,7 @@
   {
     "Command": "Backup-AzRecoveryServicesBackupItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3466,6 +3541,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupManagementServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3490,6 +3566,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3530,6 +3607,7 @@
   {
     "Command": "Register-AzRecoveryServicesBackupContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3582,6 +3660,7 @@
   {
     "Command": "Unregister-AzRecoveryServicesBackupContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3622,6 +3701,7 @@
   {
     "Command": "Disable-AzRecoveryServicesBackupProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3666,6 +3746,7 @@
   {
     "Command": "Enable-AzRecoveryServicesBackupProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3742,6 +3823,7 @@
   {
     "Command": "Enable-AzRecoveryServicesBackupAutoProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3794,6 +3876,7 @@
   {
     "Command": "Disable-AzRecoveryServicesBackupAutoProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3842,6 +3925,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3898,6 +3982,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3942,6 +4027,7 @@
   {
     "Command": "Initialize-AzRecoveryServicesBackupProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -3986,6 +4072,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4034,6 +4121,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupJobDetail",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4062,6 +4150,7 @@
   {
     "Command": "Stop-AzRecoveryServicesBackupJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4102,6 +4191,7 @@
   {
     "Command": "Wait-AzRecoveryServicesBackupJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4130,6 +4220,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupProtectionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4162,6 +4253,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupRetentionPolicyObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4186,6 +4278,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupSchedulePolicyObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4210,6 +4303,7 @@
   {
     "Command": "New-AzRecoveryServicesBackupProtectionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4262,6 +4356,7 @@
   {
     "Command": "Remove-AzRecoveryServicesBackupProtectionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4310,6 +4405,7 @@
   {
     "Command": "Set-AzRecoveryServicesBackupProtectionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4358,6 +4454,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupRecoveryPoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4398,6 +4495,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupRecoveryLogChain",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4430,6 +4528,7 @@
   {
     "Command": "Restore-AzRecoveryServicesBackupItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4530,6 +4629,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupWorkloadRecoveryConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4590,6 +4690,7 @@
   {
     "Command": "Unregister-AzRecoveryServicesBackupManagementServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4630,6 +4731,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupRPMountScript",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4670,6 +4772,7 @@
   {
     "Command": "Disable-AzRecoveryServicesBackupRPMountScript",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4710,6 +4813,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4746,6 +4850,7 @@
   {
     "Command": "Undo-AzRecoveryServicesBackupItemDeletion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4786,6 +4891,7 @@
   {
     "Command": "Set-AzRecoveryServicesVaultProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4822,6 +4928,7 @@
   {
     "Command": "Get-AzRecoveryServicesVaultProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4842,6 +4949,7 @@
   {
     "Command": "Copy-AzRecoveryServicesVault",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4886,6 +4994,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupProperties",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4906,6 +5015,7 @@
   {
     "Command": "Add-ASRReplicationProtectedItemDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -4948,6 +5058,7 @@
   {
     "Command": "Edit-ASRRP",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5006,6 +5117,7 @@
   {
     "Command": "Edit-ASRRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5064,6 +5176,7 @@
   {
     "Command": "Get-ASRAlertSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5080,6 +5193,7 @@
   {
     "Command": "Get-ASREvent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5132,6 +5246,7 @@
   {
     "Command": "Get-ASRFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5156,6 +5271,7 @@
   {
     "Command": "Get-ASRJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5196,6 +5312,7 @@
   {
     "Command": "Get-ASRNetwork",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5224,6 +5341,7 @@
   {
     "Command": "Get-ASRNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5252,6 +5370,7 @@
   {
     "Command": "Get-ASRNotificationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5268,6 +5387,7 @@
   {
     "Command": "Get-ASRPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5292,6 +5412,7 @@
   {
     "Command": "Get-ASRProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5320,6 +5441,7 @@
   {
     "Command": "Get-ASRProtectionContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5348,6 +5470,7 @@
   {
     "Command": "Get-ASRProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5372,6 +5495,7 @@
   {
     "Command": "Get-ASRRP",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5400,6 +5524,7 @@
   {
     "Command": "Get-ASRRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5428,6 +5553,7 @@
   {
     "Command": "Get-ASRRecoveryPoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5452,6 +5578,7 @@
   {
     "Command": "Get-ASRReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5484,6 +5611,7 @@
   {
     "Command": "Get-ASRServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5512,6 +5640,7 @@
   {
     "Command": "Get-ASRStorageClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5540,6 +5669,7 @@
   {
     "Command": "Get-ASRStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5564,6 +5694,7 @@
   {
     "Command": "Set-ASRVaultContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5596,6 +5727,7 @@
   {
     "Command": "Set-ASRVaultSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5628,6 +5760,7 @@
   {
     "Command": "Get-ASRvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5656,6 +5789,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrNotificationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5672,6 +5806,7 @@
   {
     "Command": "Get-AzRecoveryServicesAsrVaultSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5688,6 +5823,7 @@
   {
     "Command": "New-ASRFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5732,6 +5868,7 @@
   {
     "Command": "New-AsrInMageAzureV2DiskInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5776,6 +5913,7 @@
   {
     "Command": "New-ASRNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5836,6 +5974,7 @@
   {
     "Command": "New-ASRPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5946,6 +6085,7 @@
   {
     "Command": "New-ASRProtectableItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -5990,6 +6130,7 @@
   {
     "Command": "New-ASRProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6034,6 +6175,7 @@
   {
     "Command": "New-ASRRP",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6102,6 +6244,7 @@
   {
     "Command": "New-ASRRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6170,6 +6313,7 @@
   {
     "Command": "New-ASRReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6334,6 +6478,7 @@
   {
     "Command": "New-ASRStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6374,6 +6519,7 @@
   {
     "Command": "New-ASRvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6422,6 +6568,7 @@
   {
     "Command": "New-ASRVMNicConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6538,6 +6685,7 @@
   {
     "Command": "Remove-ASRFabric",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6576,6 +6724,7 @@
   {
     "Command": "Remove-ASRNetworkMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6610,6 +6759,7 @@
   {
     "Command": "Remove-ASRPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6644,6 +6794,7 @@
   {
     "Command": "Remove-ASRProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6682,6 +6833,7 @@
   {
     "Command": "Remove-ASRRP",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6720,6 +6872,7 @@
   {
     "Command": "Remove-ASRRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6758,6 +6911,7 @@
   {
     "Command": "Remove-ASRReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6800,6 +6954,7 @@
   {
     "Command": "Remove-ASRServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6838,6 +6993,7 @@
   {
     "Command": "Remove-ASRReplicationProtectedItemDisk",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6880,6 +7036,7 @@
   {
     "Command": "Remove-ASRStorageClassificationMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6914,6 +7071,7 @@
   {
     "Command": "Remove-ASRvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6960,6 +7118,7 @@
   {
     "Command": "Restart-ASRJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -6998,6 +7157,7 @@
   {
     "Command": "Resume-ASRJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7042,6 +7202,7 @@
   {
     "Command": "Set-ASRAlertSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7090,6 +7251,7 @@
   {
     "Command": "Set-ASRNotificationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7138,6 +7300,7 @@
   {
     "Command": "Set-ASRReplicationProtectedItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7280,6 +7443,7 @@
   {
     "Command": "Set-AzRecoveryServicesAsrNotificationSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7328,6 +7492,7 @@
   {
     "Command": "Set-AzRecoveryServicesAsrVaultSettings",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7360,6 +7525,7 @@
   {
     "Command": "Start-ASRApplyRecoveryPoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7404,6 +7570,7 @@
   {
     "Command": "Start-ASRCommitFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7440,6 +7607,7 @@
   {
     "Command": "Start-ASRCommitFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7476,6 +7644,7 @@
   {
     "Command": "Start-ASRFO",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7538,6 +7707,7 @@
   {
     "Command": "Start-ASRPFO",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7598,6 +7768,7 @@
   {
     "Command": "Start-ASRPlannedFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7658,6 +7829,7 @@
   {
     "Command": "Start-ASRResyncJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7694,6 +7866,7 @@
   {
     "Command": "Start-ASRResynchronizeReplicationJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7730,6 +7903,7 @@
   {
     "Command": "Start-ASRSwitchProcessServerJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7778,6 +7952,7 @@
   {
     "Command": "Start-ASRTFO",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7846,6 +8021,7 @@
   {
     "Command": "Start-ASRTestFailoverCleanupJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7890,6 +8066,7 @@
   {
     "Command": "Start-ASRTestFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -7958,6 +8135,7 @@
   {
     "Command": "Start-ASRUnplannedFailoverJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8020,6 +8198,7 @@
   {
     "Command": "Stop-ASRJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8058,6 +8237,7 @@
   {
     "Command": "Update-ASRMobilityService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8094,6 +8274,7 @@
   {
     "Command": "Update-ASRPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8202,6 +8383,7 @@
   {
     "Command": "Update-ASRProtectionContainerMapping",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8252,6 +8434,7 @@
   {
     "Command": "Update-ASRProtectionDirection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8384,6 +8567,7 @@
   {
     "Command": "Update-ASRRecoveryPlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8422,6 +8606,7 @@
   {
     "Command": "Update-ASRServicesProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8456,6 +8641,7 @@
   {
     "Command": "Update-ASRvCenter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8502,6 +8688,7 @@
   {
     "Command": "Set-AzRecoveryServicesBackupProperties",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [
@@ -8538,6 +8725,7 @@
   {
     "Command": "Get-AzRecoveryServicesBackupJobDetails",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RecoveryServices",
     "Version": "3.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.RedisCache.1.4.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.RedisCache.1.4.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Remove-AzRedisCachePatchSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -42,6 +43,7 @@
   {
     "Command": "New-AzRedisCacheScheduleEntry",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -70,6 +72,7 @@
   {
     "Command": "Get-AzRedisCachePatchSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -94,6 +97,7 @@
   {
     "Command": "New-AzRedisCachePatchSchedule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -134,6 +138,7 @@
   {
     "Command": "Reset-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -186,6 +191,7 @@
   {
     "Command": "Export-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -238,6 +244,7 @@
   {
     "Command": "Import-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -290,6 +297,7 @@
   {
     "Command": "Remove-AzRedisCacheDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -326,6 +334,7 @@
   {
     "Command": "Set-AzRedisCacheDiagnostic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -366,6 +375,7 @@
   {
     "Command": "Set-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -434,6 +444,7 @@
   {
     "Command": "New-AzRedisCacheKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -478,6 +489,7 @@
   {
     "Command": "Get-AzRedisCacheKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -502,6 +514,7 @@
   {
     "Command": "Get-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -526,6 +539,7 @@
   {
     "Command": "Remove-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -570,6 +584,7 @@
   {
     "Command": "New-AzRedisCache",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -654,6 +669,7 @@
   {
     "Command": "New-AzRedisCacheLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -690,6 +706,7 @@
   {
     "Command": "Remove-AzRedisCacheLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -730,6 +747,7 @@
   {
     "Command": "Get-AzRedisCacheLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -758,6 +776,7 @@
   {
     "Command": "New-AzRedisCacheFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -814,6 +833,7 @@
   {
     "Command": "Remove-AzRedisCacheFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -862,6 +882,7 @@
   {
     "Command": "Get-AzRedisCacheFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -890,6 +911,7 @@
   {
     "Command": "Set-AzRedisCacheDiagnostics",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [
@@ -930,6 +952,7 @@
   {
     "Command": "Remove-AzRedisCacheDiagnostics",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.RedisCache",
     "Version": "1.4.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Relay.1.0.3.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Relay.1.0.3.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzRelayNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -46,6 +47,7 @@
   {
     "Command": "Get-AzRelayNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -70,6 +72,7 @@
   {
     "Command": "Set-AzRelayNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -114,6 +117,7 @@
   {
     "Command": "Remove-AzRelayNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "New-AzWcfRelay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -210,6 +215,7 @@
   {
     "Command": "Get-AzWcfRelay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -238,6 +244,7 @@
   {
     "Command": "Set-AzWcfRelay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -286,6 +293,7 @@
   {
     "Command": "Remove-AzWcfRelay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -326,6 +334,7 @@
   {
     "Command": "New-AzRelayHybridConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -378,6 +387,7 @@
   {
     "Command": "Get-AzRelayHybridConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -406,6 +416,7 @@
   {
     "Command": "Set-AzRelayHybridConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -454,6 +465,7 @@
   {
     "Command": "Remove-AzRelayHybridConnection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -494,6 +506,7 @@
   {
     "Command": "Test-AzRelayName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -514,6 +527,7 @@
   {
     "Command": "Get-AzRelayOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -530,6 +544,7 @@
   {
     "Command": "New-AzRelayKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -586,6 +601,7 @@
   {
     "Command": "Get-AzRelayKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -622,6 +638,7 @@
   {
     "Command": "New-AzRelayAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -674,6 +691,7 @@
   {
     "Command": "Get-AzRelayAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -710,6 +728,7 @@
   {
     "Command": "Set-AzRelayAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [
@@ -766,6 +785,7 @@
   {
     "Command": "Remove-AzRelayAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Relay",
     "Version": "1.0.3",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Resources.3.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Resources.3.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzProviderOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -24,6 +25,7 @@
   {
     "Command": "Remove-AzRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -108,6 +110,7 @@
   {
     "Command": "Get-AzRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -180,6 +183,7 @@
   {
     "Command": "New-AzRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -265,6 +269,7 @@
   {
     "Command": "Set-AzRoleAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -305,6 +310,7 @@
   {
     "Command": "Get-AzRoleDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -337,6 +343,7 @@
   {
     "Command": "New-AzRoleDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -361,6 +368,7 @@
   {
     "Command": "Set-AzRoleDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -385,6 +393,7 @@
   {
     "Command": "Remove-AzRoleDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -437,6 +446,7 @@
   {
     "Command": "Get-AzADAppCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -469,6 +479,7 @@
   {
     "Command": "Get-AzADApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -517,6 +528,7 @@
   {
     "Command": "Add-AzADGroupMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -569,6 +581,7 @@
   {
     "Command": "Get-AzADGroupMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -612,6 +625,7 @@
   {
     "Command": "Remove-AzADGroupMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -664,6 +678,7 @@
   {
     "Command": "Get-AzADGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -706,6 +721,7 @@
   {
     "Command": "New-AzADGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -746,6 +762,7 @@
   {
     "Command": "Remove-AzADGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -794,6 +811,7 @@
   {
     "Command": "Get-AzADServicePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -850,6 +868,7 @@
   {
     "Command": "Get-AzADSpCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -884,6 +903,7 @@
   {
     "Command": "Get-AzADUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -936,6 +956,7 @@
   {
     "Command": "New-AzADAppCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -996,6 +1017,7 @@
   {
     "Command": "New-AzADSpCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1052,6 +1074,7 @@
   {
     "Command": "New-AzADUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1104,6 +1127,7 @@
   {
     "Command": "Remove-AzADAppCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1160,6 +1184,7 @@
   {
     "Command": "Remove-AzADApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1212,6 +1237,7 @@
   {
     "Command": "New-AzADApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1284,6 +1310,7 @@
   {
     "Command": "Remove-AzADServicePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1349,6 +1376,7 @@
   {
     "Command": "New-AzADServicePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1425,6 +1453,7 @@
   {
     "Command": "Remove-AzADSpCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1481,6 +1510,7 @@
   {
     "Command": "Remove-AzADUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1539,6 +1569,7 @@
   {
     "Command": "Update-AzADApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1603,6 +1634,7 @@
   {
     "Command": "Update-AzADServicePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1671,6 +1703,7 @@
   {
     "Command": "Update-AzADUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1733,6 +1766,7 @@
   {
     "Command": "Remove-AzResourceGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1790,6 +1824,7 @@
   {
     "Command": "Get-AzProviderFeature",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1818,6 +1853,7 @@
   {
     "Command": "Register-AzProviderFeature",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1854,6 +1890,7 @@
   {
     "Command": "Unregister-AzProviderFeature",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1890,6 +1927,7 @@
   {
     "Command": "Get-AzLocation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1914,6 +1952,7 @@
   {
     "Command": "Export-AzResourceGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -1984,6 +2023,7 @@
   {
     "Command": "Get-AzResourceProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2020,6 +2060,7 @@
   {
     "Command": "Register-AzResourceProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2060,6 +2101,7 @@
   {
     "Command": "Unregister-AzResourceProvider",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2100,6 +2142,7 @@
   {
     "Command": "Get-AzResourceGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2137,6 +2180,7 @@
   {
     "Command": "New-AzResourceGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2247,6 +2291,7 @@
   {
     "Command": "Remove-AzResourceGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2296,6 +2341,7 @@
   {
     "Command": "Stop-AzResourceGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2345,6 +2391,7 @@
   {
     "Command": "Test-AzResourceGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2413,6 +2460,7 @@
   {
     "Command": "Set-AzResourceGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2456,6 +2504,7 @@
   {
     "Command": "New-AzResourceGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2512,6 +2561,7 @@
   {
     "Command": "Get-AzResourceGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2557,6 +2607,7 @@
   {
     "Command": "Save-AzResourceGroupDeploymentTemplate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2609,6 +2660,7 @@
   {
     "Command": "Get-AzResourceGroupDeploymentOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2639,6 +2691,7 @@
   {
     "Command": "Get-AzResourceLock",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2697,6 +2750,7 @@
   {
     "Command": "Invoke-AzResourceAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2785,6 +2839,7 @@
   {
     "Command": "Move-AzResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2842,6 +2897,7 @@
   {
     "Command": "New-AzResourceLock",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2924,6 +2980,7 @@
   {
     "Command": "Get-AzPolicyAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -2970,6 +3027,7 @@
   {
     "Command": "Get-AzPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3020,6 +3078,7 @@
   {
     "Command": "Get-AzPolicySetDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3070,6 +3129,7 @@
   {
     "Command": "New-AzPolicyAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3146,6 +3206,7 @@
   {
     "Command": "New-AzPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3206,6 +3267,7 @@
   {
     "Command": "New-AzPolicySetDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3278,6 +3340,7 @@
   {
     "Command": "Remove-AzPolicyAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3332,6 +3395,7 @@
   {
     "Command": "Remove-AzPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3394,6 +3458,7 @@
   {
     "Command": "Remove-AzPolicySetDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3456,6 +3521,7 @@
   {
     "Command": "Set-AzPolicyAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3534,6 +3600,7 @@
   {
     "Command": "Set-AzPolicyDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3604,6 +3671,7 @@
   {
     "Command": "Set-AzPolicySetDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3686,6 +3754,7 @@
   {
     "Command": "Remove-AzResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3766,6 +3835,7 @@
   {
     "Command": "Remove-AzResourceLock",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3836,6 +3906,7 @@
   {
     "Command": "Set-AzResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -3952,6 +4023,7 @@
   {
     "Command": "New-AzResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4068,6 +4140,7 @@
   {
     "Command": "Set-AzResourceLock",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4150,6 +4223,7 @@
   {
     "Command": "Get-AzResource",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4214,6 +4288,7 @@
   {
     "Command": "Get-AzManagedApplicationDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4253,6 +4328,7 @@
   {
     "Command": "New-AzManagedApplicationDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4337,6 +4413,7 @@
   {
     "Command": "Set-AzManagedApplicationDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4409,6 +4486,7 @@
   {
     "Command": "Remove-AzManagedApplicationDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4463,6 +4541,7 @@
   {
     "Command": "Get-AzManagedApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4502,6 +4581,7 @@
   {
     "Command": "New-AzManagedApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4578,6 +4658,7 @@
   {
     "Command": "Set-AzManagedApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4656,6 +4737,7 @@
   {
     "Command": "Remove-AzManagedApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4710,6 +4792,7 @@
   {
     "Command": "Get-AzManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4752,6 +4835,7 @@
   {
     "Command": "New-AzManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4798,6 +4882,7 @@
   {
     "Command": "Update-AzManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4848,6 +4933,7 @@
   {
     "Command": "Remove-AzManagementGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4890,6 +4976,7 @@
   {
     "Command": "New-AzManagementGroupSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4932,6 +5019,7 @@
   {
     "Command": "Remove-AzManagementGroupSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -4974,6 +5062,7 @@
   {
     "Command": "New-AzDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5068,6 +5157,7 @@
   {
     "Command": "Get-AzDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5101,6 +5191,7 @@
   {
     "Command": "Test-AzDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5157,6 +5248,7 @@
   {
     "Command": "Remove-AzDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5214,6 +5306,7 @@
   {
     "Command": "Stop-AzDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5267,6 +5360,7 @@
   {
     "Command": "Save-AzDeploymentTemplate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5317,6 +5411,7 @@
   {
     "Command": "Get-AzDeploymentOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5349,6 +5444,7 @@
   {
     "Command": "Get-AzManagementGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5386,6 +5482,7 @@
   {
     "Command": "Test-AzManagementGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5446,6 +5543,7 @@
   {
     "Command": "New-AzManagementGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5544,6 +5642,7 @@
   {
     "Command": "Get-AzManagementGroupDeploymentOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5580,6 +5679,7 @@
   {
     "Command": "Save-AzManagementGroupDeploymentTemplate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5634,6 +5734,7 @@
   {
     "Command": "Stop-AzManagementGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5691,6 +5792,7 @@
   {
     "Command": "Remove-AzManagementGroupDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5752,6 +5854,7 @@
   {
     "Command": "Get-AzTenantDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5785,6 +5888,7 @@
   {
     "Command": "Test-AzTenantDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5841,6 +5945,7 @@
   {
     "Command": "New-AzTenantDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5935,6 +6040,7 @@
   {
     "Command": "Get-AzTenantDeploymentOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -5967,6 +6073,7 @@
   {
     "Command": "Save-AzTenantDeploymentTemplate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6017,6 +6124,7 @@
   {
     "Command": "Stop-AzTenantDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6070,6 +6178,7 @@
   {
     "Command": "Remove-AzTenantDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6127,6 +6236,7 @@
   {
     "Command": "Get-AzPolicyAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6193,6 +6303,7 @@
   {
     "Command": "Remove-AzTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6237,6 +6348,7 @@
   {
     "Command": "Get-AzTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6265,6 +6377,7 @@
   {
     "Command": "New-AzTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6309,6 +6422,7 @@
   {
     "Command": "Get-AzDenyAssignment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6376,6 +6490,7 @@
   {
     "Command": "Update-AzTag",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6416,6 +6531,7 @@
   {
     "Command": "Get-AzDeploymentScript",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6446,6 +6562,7 @@
   {
     "Command": "Get-AzDeploymentScriptLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6484,6 +6601,7 @@
   {
     "Command": "Save-AzDeploymentScriptLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6542,6 +6660,7 @@
   {
     "Command": "Remove-AzDeploymentScript",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6592,6 +6711,7 @@
   {
     "Command": "Get-AzDeploymentWhatIfResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6662,6 +6782,7 @@
   {
     "Command": "Get-AzResourceGroupDeploymentWhatIfResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6736,6 +6857,7 @@
   {
     "Command": "Get-AzManagementGroupDeploymentWhatIfResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6810,6 +6932,7 @@
   {
     "Command": "Get-AzTenantDeploymentWhatIfResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6880,6 +7003,7 @@
   {
     "Command": "Get-AzTemplateSpec",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6914,6 +7038,7 @@
   {
     "Command": "New-AzTemplateSpec",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -6990,6 +7115,7 @@
   {
     "Command": "Set-AzTemplateSpec",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7068,6 +7194,7 @@
   {
     "Command": "Export-AzTemplateSpec",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7118,6 +7245,7 @@
   {
     "Command": "Remove-AzTemplateSpec",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7168,6 +7296,7 @@
   {
     "Command": "Get-AzResourceProviderAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7190,6 +7319,7 @@
   {
     "Command": "Get-AzADServicePrincipalCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7224,6 +7354,7 @@
   {
     "Command": "New-AzADServicePrincipalCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7280,6 +7411,7 @@
   {
     "Command": "Remove-AzADServicePrincipalCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7336,6 +7468,7 @@
   {
     "Command": "Set-AzADApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7400,6 +7533,7 @@
   {
     "Command": "Set-AzADServicePrincipal",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7468,6 +7602,7 @@
   {
     "Command": "Set-AzADUser",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7530,6 +7665,7 @@
   {
     "Command": "New-AzSubscriptionDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7624,6 +7760,7 @@
   {
     "Command": "Get-AzSubscriptionDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7657,6 +7794,7 @@
   {
     "Command": "Test-AzSubscriptionDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7713,6 +7851,7 @@
   {
     "Command": "Remove-AzSubscriptionDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7770,6 +7909,7 @@
   {
     "Command": "Stop-AzSubscriptionDeployment",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7823,6 +7963,7 @@
   {
     "Command": "Save-AzSubscriptionDeploymentTemplate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7873,6 +8014,7 @@
   {
     "Command": "Get-AzSubscriptionDeploymentOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [
@@ -7905,6 +8047,7 @@
   {
     "Command": "Get-AzSubscriptionDeploymentWhatIfResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Resources",
     "Version": "3.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ServiceBus.1.4.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ServiceBus.1.4.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzServiceBusNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -58,6 +59,7 @@
   {
     "Command": "Get-AzServiceBusNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -86,6 +88,7 @@
   {
     "Command": "Set-AzServiceBusNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -142,6 +145,7 @@
   {
     "Command": "Remove-AzServiceBusNamespace",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -198,6 +202,7 @@
   {
     "Command": "New-AzServiceBusQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -308,6 +313,7 @@
   {
     "Command": "Get-AzServiceBusQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -346,6 +352,7 @@
   {
     "Command": "Set-AzServiceBusQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -398,6 +405,7 @@
   {
     "Command": "Remove-AzServiceBusQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -460,6 +468,7 @@
   {
     "Command": "New-AzServiceBusTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -546,6 +555,7 @@
   {
     "Command": "Get-AzServiceBusTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -584,6 +594,7 @@
   {
     "Command": "Set-AzServiceBusTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -636,6 +647,7 @@
   {
     "Command": "Remove-AzServiceBusTopic",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -698,6 +710,7 @@
   {
     "Command": "New-AzServiceBusSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -790,6 +803,7 @@
   {
     "Command": "Get-AzServiceBusSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -834,6 +848,7 @@
   {
     "Command": "Set-AzServiceBusSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -886,6 +901,7 @@
   {
     "Command": "Remove-AzServiceBusSubscription",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -954,6 +970,7 @@
   {
     "Command": "New-AzServiceBusAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1014,6 +1031,7 @@
   {
     "Command": "Get-AzServiceBusAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1062,6 +1080,7 @@
   {
     "Command": "Set-AzServiceBusAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1128,6 +1147,7 @@
   {
     "Command": "Remove-AzServiceBusAuthorizationRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1198,6 +1218,7 @@
   {
     "Command": "New-AzServiceBusKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1262,6 +1283,7 @@
   {
     "Command": "Get-AzServiceBusKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1310,6 +1332,7 @@
   {
     "Command": "Get-AzServiceBusOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1326,6 +1349,7 @@
   {
     "Command": "New-AzServiceBusRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1394,6 +1418,7 @@
   {
     "Command": "Get-AzServiceBusRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1442,6 +1467,7 @@
   {
     "Command": "Set-AzServiceBusRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1502,6 +1528,7 @@
   {
     "Command": "Remove-AzServiceBusRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1578,6 +1605,7 @@
   {
     "Command": "New-AzServiceBusGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1638,6 +1666,7 @@
   {
     "Command": "Get-AzServiceBusGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1674,6 +1703,7 @@
   {
     "Command": "Remove-AzServiceBusGeoDRConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1730,6 +1760,7 @@
   {
     "Command": "Set-AzServiceBusGeoDRConfigurationBreakPair",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1784,6 +1815,7 @@
   {
     "Command": "Set-AzServiceBusGeoDRConfigurationFailOver",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1836,6 +1868,7 @@
   {
     "Command": "Test-AzServiceBusName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1868,6 +1901,7 @@
   {
     "Command": "Get-AzServiceBusMigration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1900,6 +1934,7 @@
   {
     "Command": "Stop-AzServiceBusMigration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1950,6 +1985,7 @@
   {
     "Command": "Start-AzServiceBusMigration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -1998,6 +2034,7 @@
   {
     "Command": "Complete-AzServiceBusMigration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2046,6 +2083,7 @@
   {
     "Command": "Remove-AzServiceBusMigration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2098,6 +2136,7 @@
   {
     "Command": "Remove-AzServiceBusIPRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2152,6 +2191,7 @@
   {
     "Command": "Add-AzServiceBusIPRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2202,6 +2242,7 @@
   {
     "Command": "Remove-AzServiceBusVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2256,6 +2297,7 @@
   {
     "Command": "Add-AzServiceBusVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2306,6 +2348,7 @@
   {
     "Command": "Get-AzServiceBusNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2336,6 +2379,7 @@
   {
     "Command": "Remove-AzServiceBusNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2390,6 +2434,7 @@
   {
     "Command": "Set-AzServiceBusNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2450,6 +2495,7 @@
   {
     "Command": "New-AzServiceBusAuthorizationRuleSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [
@@ -2496,6 +2542,7 @@
   {
     "Command": "Test-AzServiceBusNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceBus",
     "Version": "1.4.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ServiceFabric.2.2.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.ServiceFabric.2.2.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzServiceFabricClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -72,6 +73,7 @@
   {
     "Command": "Add-AzServiceFabricClusterCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -164,6 +166,7 @@
   {
     "Command": "Add-AzServiceFabricNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -212,6 +215,7 @@
   {
     "Command": "Add-AzServiceFabricNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -278,6 +282,7 @@
   {
     "Command": "Get-AzServiceFabricCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -304,6 +309,7 @@
   {
     "Command": "New-AzServiceFabricCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -444,6 +450,7 @@
   {
     "Command": "Remove-AzServiceFabricClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -510,6 +517,7 @@
   {
     "Command": "Remove-AzServiceFabricClusterCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -552,6 +560,7 @@
   {
     "Command": "Remove-AzServiceFabricNode",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -600,6 +609,7 @@
   {
     "Command": "Remove-AzServiceFabricNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -642,6 +652,7 @@
   {
     "Command": "Remove-AzServiceFabricSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -692,6 +703,7 @@
   {
     "Command": "Set-AzServiceFabricSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -746,6 +758,7 @@
   {
     "Command": "Set-AzServiceFabricUpgradeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -794,6 +807,7 @@
   {
     "Command": "Update-AzServiceFabricDurability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -846,6 +860,7 @@
   {
     "Command": "Update-AzServiceFabricReliability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -896,6 +911,7 @@
   {
     "Command": "New-AzServiceFabricApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -966,6 +982,7 @@
   {
     "Command": "New-AzServiceFabricApplicationType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1008,6 +1025,7 @@
   {
     "Command": "New-AzServiceFabricApplicationTypeVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1068,6 +1086,7 @@
   {
     "Command": "New-AzServiceFabricService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1168,6 +1187,7 @@
   {
     "Command": "Update-AzServiceFabricApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1290,6 +1310,7 @@
   {
     "Command": "Get-AzServiceFabricApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1324,6 +1345,7 @@
   {
     "Command": "Get-AzServiceFabricApplicationType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1358,6 +1380,7 @@
   {
     "Command": "Get-AzServiceFabricApplicationTypeVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1398,6 +1421,7 @@
   {
     "Command": "Get-AzServiceFabricService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1436,6 +1460,7 @@
   {
     "Command": "Remove-AzServiceFabricApplication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1494,6 +1519,7 @@
   {
     "Command": "Remove-AzServiceFabricApplicationType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1552,6 +1578,7 @@
   {
     "Command": "Remove-AzServiceFabricApplicationTypeVersion",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1616,6 +1643,7 @@
   {
     "Command": "Remove-AzServiceFabricService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1678,6 +1706,7 @@
   {
     "Command": "New-AzServiceFabricManagedCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1780,6 +1809,7 @@
   {
     "Command": "Get-AzServiceFabricManagedCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1806,6 +1836,7 @@
   {
     "Command": "Set-AzServiceFabricManagedCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1880,6 +1911,7 @@
   {
     "Command": "Remove-AzServiceFabricManagedCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1934,6 +1966,7 @@
   {
     "Command": "Add-AzServiceFabricManagedClusterClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -1996,6 +2029,7 @@
   {
     "Command": "Remove-AzServiceFabricManagedClusterClientCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2054,6 +2088,7 @@
   {
     "Command": "New-AzServiceFabricManagedNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2156,6 +2191,7 @@
   {
     "Command": "Get-AzServiceFabricManagedNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2186,6 +2222,7 @@
   {
     "Command": "Set-AzServiceFabricManagedNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2284,6 +2321,7 @@
   {
     "Command": "Remove-AzServiceFabricManagedNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2350,6 +2388,7 @@
   {
     "Command": "Add-AzServiceFabricManagedNodeTypeVMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2436,6 +2475,7 @@
   {
     "Command": "Add-AzServiceFabricManagedNodeTypeVMSecret",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2498,6 +2538,7 @@
   {
     "Command": "Remove-AzServiceFabricManagedNodeTypeVMExtension",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [
@@ -2556,6 +2597,7 @@
   {
     "Command": "Restart-AzServiceFabricManagedNodeType",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.ServiceFabric",
     "Version": "2.2.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.SignalR.1.2.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.SignalR.1.2.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -66,6 +67,7 @@
   {
     "Command": "Get-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -94,6 +96,7 @@
   {
     "Command": "Get-AzSignalRKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -126,6 +129,7 @@
   {
     "Command": "New-AzSignalRKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -178,6 +182,7 @@
   {
     "Command": "Remove-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -230,6 +235,7 @@
   {
     "Command": "Update-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -298,6 +304,7 @@
   {
     "Command": "Test-AzSignalRName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -322,6 +329,7 @@
   {
     "Command": "Restart-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -374,6 +382,7 @@
   {
     "Command": "Get-AzSignalRUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -394,6 +403,7 @@
   {
     "Command": "Update-AzSignalRNetworkAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -462,6 +472,7 @@
   {
     "Command": "Set-AzSignalRUpstream",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [
@@ -518,6 +529,7 @@
   {
     "Command": "Test-AzSignalR",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SignalR",
     "Version": "1.2.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Sql.2.13.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Sql.2.13.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzSqlDatabaseTransparentDataEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -42,6 +43,7 @@
   {
     "Command": "Get-AzSqlDatabaseTransparentDataEncryptionActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -82,6 +84,7 @@
   {
     "Command": "Set-AzSqlDatabaseTransparentDataEncryption",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -126,6 +129,7 @@
   {
     "Command": "Get-AzSqlDatabaseUpgradeHint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -170,6 +174,7 @@
   {
     "Command": "Get-AzSqlServerUpgradeHint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -210,6 +215,7 @@
   {
     "Command": "Get-AzSqlServerServiceObjective",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -254,6 +260,7 @@
   {
     "Command": "Get-AzSqlServerActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -290,6 +297,7 @@
   {
     "Command": "Remove-AzSqlServerActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -330,6 +338,7 @@
   {
     "Command": "Set-AzSqlServerActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -374,6 +383,7 @@
   {
     "Command": "Get-AzSqlServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -412,6 +422,7 @@
   {
     "Command": "New-AzSqlServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -484,6 +495,7 @@
   {
     "Command": "Remove-AzSqlServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -526,6 +538,7 @@
   {
     "Command": "Set-AzSqlServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -594,6 +607,7 @@
   {
     "Command": "Get-AzSqlServerCommunicationLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -634,6 +648,7 @@
   {
     "Command": "New-AzSqlServerCommunicationLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -682,6 +697,7 @@
   {
     "Command": "Remove-AzSqlServerCommunicationLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -726,6 +742,7 @@
   {
     "Command": "Get-AzSqlDatabaseReplicationLink",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -774,6 +791,7 @@
   {
     "Command": "New-AzSqlDatabaseCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -864,6 +882,7 @@
   {
     "Command": "New-AzSqlDatabaseSecondary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -962,6 +981,7 @@
   {
     "Command": "Remove-AzSqlDatabaseSecondary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1010,6 +1030,7 @@
   {
     "Command": "Set-AzSqlDatabaseSecondary",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1066,6 +1087,7 @@
   {
     "Command": "Get-AzSqlElasticPoolRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1102,6 +1124,7 @@
   {
     "Command": "Get-AzSqlDatabaseIndexRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1150,6 +1173,7 @@
   {
     "Command": "Start-AzSqlDatabaseExecuteIndexRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1182,6 +1206,7 @@
   {
     "Command": "Stop-AzSqlDatabaseExecuteIndexRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1214,6 +1239,7 @@
   {
     "Command": "Get-AzSqlServerFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1256,6 +1282,7 @@
   {
     "Command": "New-AzSqlServerFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1310,6 +1337,7 @@
   {
     "Command": "Remove-AzSqlServerFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1356,6 +1384,7 @@
   {
     "Command": "Set-AzSqlServerFirewallRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1406,6 +1435,7 @@
   {
     "Command": "Get-AzSqlElasticPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1436,6 +1466,7 @@
   {
     "Command": "Get-AzSqlElasticPoolActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1480,6 +1511,7 @@
   {
     "Command": "Get-AzSqlElasticPoolDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1524,6 +1556,7 @@
   {
     "Command": "New-AzSqlElasticPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1620,6 +1653,7 @@
   {
     "Command": "Remove-AzSqlElasticPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1666,6 +1700,7 @@
   {
     "Command": "Set-AzSqlElasticPool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1764,6 +1799,7 @@
   {
     "Command": "Get-AzSqlServerDisasterRecoveryConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1804,6 +1840,7 @@
   {
     "Command": "Get-AzSqlServerDisasterRecoveryConfigurationActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1848,6 +1885,7 @@
   {
     "Command": "New-AzSqlServerDisasterRecoveryConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1904,6 +1942,7 @@
   {
     "Command": "Remove-AzSqlServerDisasterRecoveryConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -1948,6 +1987,7 @@
   {
     "Command": "Set-AzSqlServerDisasterRecoveryConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2000,6 +2040,7 @@
   {
     "Command": "Resume-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2044,6 +2085,7 @@
   {
     "Command": "Suspend-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2088,6 +2130,7 @@
   {
     "Command": "Get-AzSqlDatabaseDataMaskingPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2128,6 +2171,7 @@
   {
     "Command": "Get-AzSqlDatabaseDataMaskingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2180,6 +2224,7 @@
   {
     "Command": "New-AzSqlDatabaseDataMaskingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2260,6 +2305,7 @@
   {
     "Command": "Remove-AzSqlDatabaseDataMaskingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2320,6 +2366,7 @@
   {
     "Command": "Set-AzSqlDatabaseDataMaskingPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2372,6 +2419,7 @@
   {
     "Command": "Set-AzSqlDatabaseDataMaskingRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2452,6 +2500,7 @@
   {
     "Command": "Get-AzSqlCapability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2500,6 +2549,7 @@
   {
     "Command": "Get-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2542,6 +2592,7 @@
   {
     "Command": "Get-AzSqlDatabaseActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2590,6 +2641,7 @@
   {
     "Command": "Get-AzSqlDatabaseExpanded",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2630,6 +2682,7 @@
   {
     "Command": "New-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2769,6 +2822,7 @@
   {
     "Command": "Remove-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2815,6 +2869,7 @@
   {
     "Command": "Set-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2942,6 +2997,7 @@
   {
     "Command": "Get-AzSqlDatabaseImportExportStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -2974,6 +3030,7 @@
   {
     "Command": "New-AzSqlDatabaseExport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3050,6 +3107,7 @@
   {
     "Command": "New-AzSqlDatabaseImport",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3138,6 +3196,7 @@
   {
     "Command": "Get-AzSqlDatabaseGeoBackupPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3166,6 +3225,7 @@
   {
     "Command": "Set-AzSqlDatabaseGeoBackupPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3210,6 +3270,7 @@
   {
     "Command": "Get-AzSqlDatabaseBackupShortTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3248,6 +3309,7 @@
   {
     "Command": "Set-AzSqlDatabaseBackupShortTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3302,6 +3364,7 @@
   {
     "Command": "Get-AzSqlDatabaseBackupLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3342,6 +3405,7 @@
   {
     "Command": "Set-AzSqlDatabaseBackupLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3402,6 +3466,7 @@
   {
     "Command": "Get-AzSqlDatabaseLongTermRetentionBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3466,6 +3531,7 @@
   {
     "Command": "Remove-AzSqlDatabaseLongTermRetentionBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3526,6 +3592,7 @@
   {
     "Command": "Get-AzSqlDeletedDatabaseBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3570,6 +3637,7 @@
   {
     "Command": "Get-AzSqlDatabaseGeoBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3610,6 +3678,7 @@
   {
     "Command": "Restore-AzSqlDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3716,6 +3785,7 @@
   {
     "Command": "Get-AzSqlDatabaseRestorePoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3756,6 +3826,7 @@
   {
     "Command": "Get-AzSqlDatabaseRecommendedAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3792,6 +3863,7 @@
   {
     "Command": "Get-AzSqlElasticPoolRecommendedAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3828,6 +3900,7 @@
   {
     "Command": "Get-AzSqlServerRecommendedAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3860,6 +3933,7 @@
   {
     "Command": "Set-AzSqlDatabaseRecommendedActionState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3912,6 +3986,7 @@
   {
     "Command": "Set-AzSqlElasticPoolRecommendedActionState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -3964,6 +4039,7 @@
   {
     "Command": "Set-AzSqlServerRecommendedActionState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4012,6 +4088,7 @@
   {
     "Command": "Get-AzSqlElasticPoolAdvisor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4048,6 +4125,7 @@
   {
     "Command": "Get-AzSqlServerAdvisor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4080,6 +4158,7 @@
   {
     "Command": "Set-AzSqlElasticPoolAdvisorAutoExecuteStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4128,6 +4207,7 @@
   {
     "Command": "Set-AzSqlServerAdvisorAutoExecuteStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4172,6 +4252,7 @@
   {
     "Command": "Get-AzSqlDatabaseAdvisor",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4208,6 +4289,7 @@
   {
     "Command": "Set-AzSqlDatabaseAdvisorAutoExecuteStatus",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4256,6 +4338,7 @@
   {
     "Command": "Get-AzSqlServerTransparentDataEncryptionProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4292,6 +4375,7 @@
   {
     "Command": "Set-AzSqlServerTransparentDataEncryptionProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4344,6 +4428,7 @@
   {
     "Command": "Add-AzSqlServerKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4388,6 +4473,7 @@
   {
     "Command": "Get-AzSqlServerKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4428,6 +4514,7 @@
   {
     "Command": "Remove-AzSqlServerKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4472,6 +4559,7 @@
   {
     "Command": "Get-AzSqlDatabaseFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4500,6 +4588,7 @@
   {
     "Command": "New-AzSqlDatabaseFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4548,6 +4637,7 @@
   {
     "Command": "Add-AzSqlDatabaseToFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4580,6 +4670,7 @@
   {
     "Command": "Remove-AzSqlDatabaseFromFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4628,6 +4719,7 @@
   {
     "Command": "Remove-AzSqlDatabaseFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4672,6 +4764,7 @@
   {
     "Command": "Set-AzSqlDatabaseFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4712,6 +4805,7 @@
   {
     "Command": "Switch-AzSqlDatabaseFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4760,6 +4854,7 @@
   {
     "Command": "New-AzSqlSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4838,6 +4933,7 @@
   {
     "Command": "Update-AzSqlSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4900,6 +4996,7 @@
   {
     "Command": "Get-AzSqlSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4934,6 +5031,7 @@
   {
     "Command": "Get-AzSqlSyncGroupLog",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -4980,6 +5078,7 @@
   {
     "Command": "Remove-AzSqlSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5034,6 +5133,7 @@
   {
     "Command": "Update-AzSqlSyncSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5086,6 +5186,7 @@
   {
     "Command": "Get-AzSqlSyncSchema",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5122,6 +5223,7 @@
   {
     "Command": "Start-AzSqlSyncGroupSync",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5172,6 +5274,7 @@
   {
     "Command": "Stop-AzSqlSyncGroupSync",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5222,6 +5325,7 @@
   {
     "Command": "New-AzSqlSyncMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5320,6 +5424,7 @@
   {
     "Command": "Update-AzSqlSyncMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5382,6 +5487,7 @@
   {
     "Command": "Get-AzSqlSyncMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5420,6 +5526,7 @@
   {
     "Command": "Remove-AzSqlSyncMember",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5478,6 +5585,7 @@
   {
     "Command": "New-AzSqlSyncAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5536,6 +5644,7 @@
   {
     "Command": "Get-AzSqlSyncAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5566,6 +5675,7 @@
   {
     "Command": "Remove-AzSqlSyncAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5616,6 +5726,7 @@
   {
     "Command": "New-AzSqlSyncAgentKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5656,6 +5767,7 @@
   {
     "Command": "Get-AzSqlSyncAgentLinkedDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5686,6 +5798,7 @@
   {
     "Command": "New-AzSqlServerVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5738,6 +5851,7 @@
   {
     "Command": "Set-AzSqlServerVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5790,6 +5904,7 @@
   {
     "Command": "Get-AzSqlServerVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5818,6 +5933,7 @@
   {
     "Command": "Remove-AzSqlServerVirtualNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5862,6 +5978,7 @@
   {
     "Command": "Stop-AzSqlDatabaseActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5910,6 +6027,7 @@
   {
     "Command": "Get-AzSqlServerDnsAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -5952,6 +6070,7 @@
   {
     "Command": "Remove-AzSqlServerDnsAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6010,6 +6129,7 @@
   {
     "Command": "New-AzSqlServerDnsAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6056,6 +6176,7 @@
   {
     "Command": "Set-AzSqlServerDnsAlias",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6116,6 +6237,7 @@
   {
     "Command": "New-AzSqlDatabaseRestorePoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6160,6 +6282,7 @@
   {
     "Command": "Remove-AzSqlDatabaseRestorePoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6208,6 +6331,7 @@
   {
     "Command": "Stop-AzSqlElasticPoolActivity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6256,6 +6380,7 @@
   {
     "Command": "Add-AzSqlServerTransparentDataEncryptionCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6312,6 +6437,7 @@
   {
     "Command": "Add-AzSqlManagedInstanceTransparentDataEncryptionCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6360,6 +6486,7 @@
   {
     "Command": "Update-AzSqlDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6428,6 +6555,7 @@
   {
     "Command": "Get-AzSqlDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6460,6 +6588,7 @@
   {
     "Command": "Clear-AzSqlDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6504,6 +6633,7 @@
   {
     "Command": "Set-AzSqlDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6560,6 +6690,7 @@
   {
     "Command": "Get-AzSqlDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6600,6 +6731,7 @@
   {
     "Command": "Clear-AzSqlDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6652,6 +6784,7 @@
   {
     "Command": "Convert-AzSqlDatabaseVulnerabilityAssessmentScan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6700,6 +6833,7 @@
   {
     "Command": "Get-AzSqlDatabaseVulnerabilityAssessmentScanRecord",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6736,6 +6870,7 @@
   {
     "Command": "Start-AzSqlDatabaseVulnerabilityAssessmentScan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6788,6 +6923,7 @@
   {
     "Command": "Get-AzSqlInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6832,6 +6968,7 @@
   {
     "Command": "New-AzSqlInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -6972,6 +7109,7 @@
   {
     "Command": "Remove-AzSqlInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7024,6 +7162,7 @@
   {
     "Command": "Get-AzSqlInstanceOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7060,6 +7199,7 @@
   {
     "Command": "Stop-AzSqlInstanceOperation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7116,6 +7256,7 @@
   {
     "Command": "Set-AzSqlInstance",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7226,6 +7367,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7268,6 +7410,7 @@
   {
     "Command": "New-AzSqlInstanceDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7336,6 +7479,7 @@
   {
     "Command": "Remove-AzSqlInstanceDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7392,6 +7536,7 @@
   {
     "Command": "Restore-AzSqlInstanceDatabase",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7497,6 +7642,7 @@
   {
     "Command": "Update-AzSqlInstanceDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7565,6 +7711,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7597,6 +7744,7 @@
   {
     "Command": "Clear-AzSqlInstanceDatabaseVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7641,6 +7789,7 @@
   {
     "Command": "Set-AzSqlInstanceDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7697,6 +7846,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7737,6 +7887,7 @@
   {
     "Command": "Clear-AzSqlInstanceDatabaseVulnerabilityAssessmentRuleBaseline",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7789,6 +7940,7 @@
   {
     "Command": "Convert-AzSqlInstanceDatabaseVulnerabilityAssessmentScan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7837,6 +7989,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseVulnerabilityAssessmentScanRecord",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7873,6 +8026,7 @@
   {
     "Command": "Start-AzSqlInstanceDatabaseVulnerabilityAssessmentScan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7925,6 +8079,7 @@
   {
     "Command": "Enable-AzSqlInstanceAdvancedDataSecurity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -7977,6 +8132,7 @@
   {
     "Command": "Disable-AzSqlInstanceAdvancedDataSecurity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8017,6 +8173,7 @@
   {
     "Command": "Get-AzSqlInstanceAdvancedDataSecurityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8045,6 +8202,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseGeoBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8075,6 +8233,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseBackupShortTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8118,6 +8277,7 @@
   {
     "Command": "Set-AzSqlInstanceDatabaseBackupShortTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8177,6 +8337,7 @@
   {
     "Command": "Get-AzSqlDeletedInstanceDatabaseBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8209,6 +8370,7 @@
   {
     "Command": "Update-AzSqlInstanceVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8273,6 +8435,7 @@
   {
     "Command": "Get-AzSqlInstanceVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8301,6 +8464,7 @@
   {
     "Command": "Clear-AzSqlInstanceVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8341,6 +8505,7 @@
   {
     "Command": "Update-AzSqlServerVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8405,6 +8570,7 @@
   {
     "Command": "Get-AzSqlServerVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8433,6 +8599,7 @@
   {
     "Command": "Clear-AzSqlServerVulnerabilityAssessmentSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8473,6 +8640,7 @@
   {
     "Command": "Get-AzSqlDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8521,6 +8689,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8569,6 +8738,7 @@
   {
     "Command": "Set-AzSqlDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8645,6 +8815,7 @@
   {
     "Command": "Set-AzSqlInstanceDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8721,6 +8892,7 @@
   {
     "Command": "Remove-AzSqlDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8789,6 +8961,7 @@
   {
     "Command": "Remove-AzSqlInstanceDatabaseSensitivityClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8857,6 +9030,7 @@
   {
     "Command": "Get-AzSqlDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8893,6 +9067,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8929,6 +9104,7 @@
   {
     "Command": "Get-AzSqlVirtualCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -8959,6 +9135,7 @@
   {
     "Command": "Remove-AzSqlVirtualCluster",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9011,6 +9188,7 @@
   {
     "Command": "Enable-AzSqlServerAdvancedDataSecurity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9063,6 +9241,7 @@
   {
     "Command": "Disable-AzSqlServerAdvancedDataSecurity",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9103,6 +9282,7 @@
   {
     "Command": "Get-AzSqlServerAdvancedDataSecurityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9131,6 +9311,7 @@
   {
     "Command": "Get-AzSqlDatabaseInstanceFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9159,6 +9340,7 @@
   {
     "Command": "New-AzSqlDatabaseInstanceFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9231,6 +9413,7 @@
   {
     "Command": "Remove-AzSqlDatabaseInstanceFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9287,6 +9470,7 @@
   {
     "Command": "Set-AzSqlDatabaseInstanceFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9347,6 +9531,7 @@
   {
     "Command": "Switch-AzSqlDatabaseInstanceFailoverGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9399,6 +9584,7 @@
   {
     "Command": "Get-AzSqlServerAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9435,6 +9621,7 @@
   {
     "Command": "Clear-AzSqlServerAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9475,6 +9662,7 @@
   {
     "Command": "Update-AzSqlServerAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9535,6 +9723,7 @@
   {
     "Command": "Get-AzSqlDatabaseAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9575,6 +9764,7 @@
   {
     "Command": "Update-AzSqlDatabaseAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9639,6 +9829,7 @@
   {
     "Command": "Clear-AzSqlDatabaseAdvancedThreatProtectionSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9683,6 +9874,7 @@
   {
     "Command": "Add-AzSqlInstanceKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9735,6 +9927,7 @@
   {
     "Command": "Get-AzSqlInstanceKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9787,6 +9980,7 @@
   {
     "Command": "Remove-AzSqlInstanceKeyVaultKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9839,6 +10033,7 @@
   {
     "Command": "Get-AzSqlInstanceTransparentDataEncryptionProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9887,6 +10082,7 @@
   {
     "Command": "Set-AzSqlInstanceTransparentDataEncryptionProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9947,6 +10143,7 @@
   {
     "Command": "Get-AzSqlServerAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -9979,6 +10176,7 @@
   {
     "Command": "Get-AzSqlDatabaseAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10011,6 +10209,7 @@
   {
     "Command": "Set-AzSqlServerAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10103,6 +10302,7 @@
   {
     "Command": "Set-AzSqlDatabaseAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10199,6 +10399,7 @@
   {
     "Command": "Get-AzSqlInstanceActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10231,6 +10432,7 @@
   {
     "Command": "Remove-AzSqlInstanceActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10283,6 +10485,7 @@
   {
     "Command": "Set-AzSqlInstanceActiveDirectoryAdministrator",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10335,6 +10538,7 @@
   {
     "Command": "Remove-AzSqlServerAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10379,6 +10583,7 @@
   {
     "Command": "Remove-AzSqlDatabaseAudit",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10423,6 +10628,7 @@
   {
     "Command": "Get-AzSqlInstancePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10453,6 +10659,7 @@
   {
     "Command": "Set-AzSqlInstancePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10513,6 +10720,7 @@
   {
     "Command": "New-AzSqlInstancePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10587,6 +10795,7 @@
   {
     "Command": "Remove-AzSqlInstancePool",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10633,6 +10842,7 @@
   {
     "Command": "Get-AzSqlInstancePoolUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10673,6 +10883,7 @@
   {
     "Command": "Invoke-AzSqlDatabaseFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10731,6 +10942,7 @@
   {
     "Command": "Invoke-AzSqlElasticPoolFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10785,6 +10997,7 @@
   {
     "Command": "New-AzSqlElasticJobAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10845,6 +11058,7 @@
   {
     "Command": "Remove-AzSqlElasticJobAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10899,6 +11113,7 @@
   {
     "Command": "Get-AzSqlElasticJobAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10937,6 +11152,7 @@
   {
     "Command": "Set-AzSqlElasticJobAgent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -10993,6 +11209,7 @@
   {
     "Command": "New-AzSqlElasticJobCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11051,6 +11268,7 @@
   {
     "Command": "Get-AzSqlElasticJobCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11093,6 +11311,7 @@
   {
     "Command": "Set-AzSqlElasticJobCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11151,6 +11370,7 @@
   {
     "Command": "Remove-AzSqlElasticJobCredential",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11205,6 +11425,7 @@
   {
     "Command": "New-AzSqlElasticJobTargetGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11259,6 +11480,7 @@
   {
     "Command": "Get-AzSqlElasticJobTargetGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11301,6 +11523,7 @@
   {
     "Command": "Remove-AzSqlElasticJobTargetGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11359,6 +11582,7 @@
   {
     "Command": "Add-AzSqlElasticJobTarget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11435,6 +11659,7 @@
   {
     "Command": "Remove-AzSqlElasticJobTarget",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11507,6 +11732,7 @@
   {
     "Command": "New-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11589,6 +11815,7 @@
   {
     "Command": "Get-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11631,6 +11858,7 @@
   {
     "Command": "Set-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11713,6 +11941,7 @@
   {
     "Command": "Remove-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11771,6 +12000,7 @@
   {
     "Command": "Add-AzSqlElasticJobStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11885,6 +12115,7 @@
   {
     "Command": "Get-AzSqlElasticJobStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11935,6 +12166,7 @@
   {
     "Command": "Remove-AzSqlElasticJobStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -11993,6 +12225,7 @@
   {
     "Command": "Set-AzSqlElasticJobStep",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12111,6 +12344,7 @@
   {
     "Command": "Start-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12171,6 +12405,7 @@
   {
     "Command": "Stop-AzSqlElasticJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12227,6 +12462,7 @@
   {
     "Command": "Get-AzSqlElasticJobExecution",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12295,6 +12531,7 @@
   {
     "Command": "Get-AzSqlElasticJobStepExecution",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12363,6 +12600,7 @@
   {
     "Command": "Get-AzSqlElasticJobTargetExecution",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12435,6 +12673,7 @@
   {
     "Command": "Enable-AzSqlDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12505,6 +12744,7 @@
   {
     "Command": "Disable-AzSqlDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12575,6 +12815,7 @@
   {
     "Command": "Enable-AzSqlInstanceDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12645,6 +12886,7 @@
   {
     "Command": "Disable-AzSqlInstanceDatabaseSensitivityRecommendation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12715,6 +12957,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseLongTermRetentionBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12779,6 +13022,7 @@
   {
     "Command": "Remove-AzSqlInstanceDatabaseLongTermRetentionBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12839,6 +13083,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseBackupLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12879,6 +13124,7 @@
   {
     "Command": "Set-AzSqlInstanceDatabaseBackupLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12939,6 +13185,7 @@
   {
     "Command": "Disable-AzSqlServerActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -12983,6 +13230,7 @@
   {
     "Command": "Invoke-AzSqlInstanceFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13037,6 +13285,7 @@
   {
     "Command": "Enable-AzSqlServerActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13081,6 +13330,7 @@
   {
     "Command": "Get-AzSqlServerActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13125,6 +13375,7 @@
   {
     "Command": "Start-AzSqlInstanceDatabaseLogReplay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13203,6 +13454,7 @@
   {
     "Command": "Complete-AzSqlInstanceDatabaseLogReplay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13261,6 +13513,7 @@
   {
     "Command": "Stop-AzSqlInstanceDatabaseLogReplay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13319,6 +13572,7 @@
   {
     "Command": "Get-AzSqlInstanceDatabaseLogReplay",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13351,6 +13605,7 @@
   {
     "Command": "Disable-AzSqlInstanceActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13395,6 +13650,7 @@
   {
     "Command": "Enable-AzSqlInstanceActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13439,6 +13695,7 @@
   {
     "Command": "Get-AzSqlInstanceActiveDirectoryOnlyAuthentication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13483,6 +13740,7 @@
   {
     "Command": "Get-AzSqlDatabaseLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13523,6 +13781,7 @@
   {
     "Command": "Set-AzSqlDatabaseLongTermRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13583,6 +13842,7 @@
   {
     "Command": "Enable-AzSqlServerAdvancedThreatProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13635,6 +13895,7 @@
   {
     "Command": "Disable-AzSqlServerAdvancedThreatProtection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13675,6 +13936,7 @@
   {
     "Command": "Set-AzSqlInstanceTDEProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [
@@ -13735,6 +13997,7 @@
   {
     "Command": "Get-AzSqlInstanceTDEProtector",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Sql",
     "Version": "2.13.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.SqlVirtualMachine.1.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.SqlVirtualMachine.1.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "New-AzSqlVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -72,6 +73,7 @@
   {
     "Command": "Get-AzSqlVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -104,6 +106,7 @@
   {
     "Command": "Update-AzSqlVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -178,6 +181,7 @@
   {
     "Command": "Remove-AzSqlVM",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -236,6 +240,7 @@
   {
     "Command": "New-AzSqlVMConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -284,6 +289,7 @@
   {
     "Command": "Set-AzSqlVMConfigGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -332,6 +338,7 @@
   {
     "Command": "New-AzSqlVMGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -422,6 +429,7 @@
   {
     "Command": "Get-AzSqlVMGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -454,6 +462,7 @@
   {
     "Command": "Update-AzSqlVMGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -544,6 +553,7 @@
   {
     "Command": "Remove-AzSqlVMGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -602,6 +612,7 @@
   {
     "Command": "New-AzAvailabilityGroupListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -684,6 +695,7 @@
   {
     "Command": "Get-AzAvailabilityGroupListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -722,6 +734,7 @@
   {
     "Command": "Update-AzAvailabilityGroupListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [
@@ -786,6 +799,7 @@
   {
     "Command": "Remove-AzAvailabilityGroupListener",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.SqlVirtualMachine",
     "Version": "1.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Storage.3.1.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Storage.3.1.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -41,6 +42,7 @@
   {
     "Command": "Get-AzStorageAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -72,6 +74,7 @@
   {
     "Command": "New-AzStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -209,6 +212,7 @@
   {
     "Command": "New-AzStorageAccountKey",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -240,6 +244,7 @@
   {
     "Command": "Remove-AzStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -287,6 +292,7 @@
   {
     "Command": "Set-AzCurrentStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -318,6 +324,7 @@
   {
     "Command": "Set-AzStorageAccount",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -471,6 +478,7 @@
   {
     "Command": "Get-AzStorageAccountNameAvailability",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -494,6 +502,7 @@
   {
     "Command": "Get-AzStorageUsage",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -514,6 +523,7 @@
   {
     "Command": "Update-AzStorageAccountNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -573,6 +583,7 @@
   {
     "Command": "Get-AzStorageAccountNetworkRuleSet",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -600,6 +611,7 @@
   {
     "Command": "Add-AzStorageAccountNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -662,6 +674,7 @@
   {
     "Command": "Remove-AzStorageAccountNetworkRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -724,6 +737,7 @@
   {
     "Command": "Get-AzStorageTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -754,6 +768,7 @@
   {
     "Command": "New-AzStorageTableSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -832,6 +847,7 @@
   {
     "Command": "New-AzStorageTableStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -874,6 +890,7 @@
   {
     "Command": "New-AzStorageTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -900,6 +917,7 @@
   {
     "Command": "Remove-AzStorageTableStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -946,6 +964,7 @@
   {
     "Command": "Remove-AzStorageTable",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -992,6 +1011,7 @@
   {
     "Command": "Get-AzStorageTableStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1022,6 +1042,7 @@
   {
     "Command": "Set-AzStorageTableStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1084,6 +1105,7 @@
   {
     "Command": "Get-AzStorageQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1114,6 +1136,7 @@
   {
     "Command": "New-AzStorageQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1140,6 +1163,7 @@
   {
     "Command": "Remove-AzStorageQueue",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1186,6 +1210,7 @@
   {
     "Command": "Get-AzStorageQueueStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1216,6 +1241,7 @@
   {
     "Command": "New-AzStorageQueueSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1270,6 +1296,7 @@
   {
     "Command": "New-AzStorageQueueStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1312,6 +1339,7 @@
   {
     "Command": "Remove-AzStorageQueueStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1358,6 +1386,7 @@
   {
     "Command": "Set-AzStorageQueueStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1420,6 +1449,7 @@
   {
     "Command": "Get-AzStorageFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1475,6 +1505,7 @@
   {
     "Command": "Get-AzStorageFileContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1572,6 +1603,7 @@
   {
     "Command": "Get-AzStorageFileCopyState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1625,6 +1657,7 @@
   {
     "Command": "Get-AzStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1672,6 +1705,7 @@
   {
     "Command": "Get-AzStorageShareStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1718,6 +1752,7 @@
   {
     "Command": "New-AzStorageDirectory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1773,6 +1808,7 @@
   {
     "Command": "New-AzStorageFileSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1834,6 +1870,7 @@
   {
     "Command": "New-AzStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1873,6 +1910,7 @@
   {
     "Command": "New-AzStorageShareSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1927,6 +1965,7 @@
   {
     "Command": "New-AzStorageShareStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -1985,6 +2024,7 @@
   {
     "Command": "Remove-AzStorageDirectory",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2056,6 +2096,7 @@
   {
     "Command": "Remove-AzStorageFile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2133,6 +2174,7 @@
   {
     "Command": "Remove-AzStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2202,6 +2244,7 @@
   {
     "Command": "Remove-AzStorageShareStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2264,6 +2307,7 @@
   {
     "Command": "Set-AzStorageFileContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": true,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2353,6 +2397,7 @@
   {
     "Command": "Set-AzStorageShareQuota",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2407,6 +2452,7 @@
   {
     "Command": "Set-AzStorageShareStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2485,6 +2531,7 @@
   {
     "Command": "Start-AzStorageFileCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2596,6 +2643,7 @@
   {
     "Command": "Stop-AzStorageFileCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2665,6 +2713,7 @@
   {
     "Command": "New-AzStorageAccountSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2712,6 +2761,7 @@
   {
     "Command": "Set-AzStorageCORSRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2759,6 +2809,7 @@
   {
     "Command": "Get-AzStorageCORSRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2798,6 +2849,7 @@
   {
     "Command": "Get-AzStorageServiceLoggingProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2821,6 +2873,7 @@
   {
     "Command": "Get-AzStorageServiceMetricsProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2848,6 +2901,7 @@
   {
     "Command": "Remove-AzStorageCORSRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2887,6 +2941,7 @@
   {
     "Command": "Set-AzStorageServiceLoggingProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2926,6 +2981,7 @@
   {
     "Command": "Set-AzStorageServiceMetricsProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -2969,6 +3025,7 @@
   {
     "Command": "New-AzStorageContext",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3020,6 +3077,7 @@
   {
     "Command": "Set-AzStorageContainerAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3072,6 +3130,7 @@
   {
     "Command": "Remove-AzStorageBlob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3161,6 +3220,7 @@
   {
     "Command": "Set-AzStorageBlobContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3260,6 +3320,7 @@
   {
     "Command": "Get-AzStorageBlob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3334,6 +3395,7 @@
   {
     "Command": "Get-AzStorageBlobContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3421,6 +3483,7 @@
   {
     "Command": "Get-AzStorageBlobCopyState",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3478,6 +3541,7 @@
   {
     "Command": "Get-AzStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3532,6 +3596,7 @@
   {
     "Command": "Get-AzStorageContainerStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3578,6 +3643,7 @@
   {
     "Command": "New-AzStorageBlobSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3655,6 +3721,7 @@
   {
     "Command": "New-AzStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3703,6 +3770,7 @@
   {
     "Command": "New-AzStorageContainerSASToken",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3769,6 +3837,7 @@
   {
     "Command": "New-AzStorageContainerStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3827,6 +3896,7 @@
   {
     "Command": "Remove-AzStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3889,6 +3959,7 @@
   {
     "Command": "Remove-AzStorageContainerStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -3951,6 +4022,7 @@
   {
     "Command": "Set-AzStorageContainerStoredAccessPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4029,6 +4101,7 @@
   {
     "Command": "Start-AzStorageBlobCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4190,6 +4263,7 @@
   {
     "Command": "Start-AzStorageBlobIncrementalCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4307,6 +4381,7 @@
   {
     "Command": "Stop-AzStorageBlobCopy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4380,6 +4455,7 @@
   {
     "Command": "Update-AzStorageServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4423,6 +4499,7 @@
   {
     "Command": "Get-AzStorageServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4446,6 +4523,7 @@
   {
     "Command": "Enable-AzStorageDeleteRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4487,6 +4565,7 @@
   {
     "Command": "Disable-AzStorageDeleteRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4522,6 +4601,7 @@
   {
     "Command": "Enable-AzStorageStaticWebsite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4565,6 +4645,7 @@
   {
     "Command": "Disable-AzStorageStaticWebsite",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4600,6 +4681,7 @@
   {
     "Command": "Get-AzRmStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4641,6 +4723,7 @@
   {
     "Command": "Update-AzRmStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4704,6 +4787,7 @@
   {
     "Command": "New-AzRmStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4761,6 +4845,7 @@
   {
     "Command": "Remove-AzRmStorageContainer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4824,6 +4909,7 @@
   {
     "Command": "Add-AzRmStorageContainerLegalHold",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4881,6 +4967,7 @@
   {
     "Command": "Remove-AzRmStorageContainerLegalHold",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -4938,6 +5025,7 @@
   {
     "Command": "Set-AzRmStorageContainerImmutabilityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5016,6 +5104,7 @@
   {
     "Command": "Get-AzRmStorageContainerImmutabilityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5062,6 +5151,7 @@
   {
     "Command": "Remove-AzRmStorageContainerImmutabilityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5126,6 +5216,7 @@
   {
     "Command": "Lock-AzRmStorageContainerImmutabilityPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5194,6 +5285,7 @@
   {
     "Command": "Set-AzStorageAccountManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5250,6 +5342,7 @@
   {
     "Command": "Get-AzStorageAccountManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5284,6 +5377,7 @@
   {
     "Command": "Remove-AzStorageAccountManagementPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5340,6 +5434,7 @@
   {
     "Command": "New-AzStorageAccountManagementPolicyFilter",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5360,6 +5455,7 @@
   {
     "Command": "New-AzStorageAccountManagementPolicyRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5392,6 +5488,7 @@
   {
     "Command": "Add-AzStorageAccountManagementPolicyAction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5428,6 +5525,7 @@
   {
     "Command": "Update-AzStorageBlobServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5487,6 +5585,7 @@
   {
     "Command": "Get-AzStorageBlobServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5522,6 +5621,7 @@
   {
     "Command": "Enable-AzStorageBlobDeleteRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5579,6 +5679,7 @@
   {
     "Command": "Disable-AzStorageBlobDeleteRetentionPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5630,6 +5731,7 @@
   {
     "Command": "Revoke-AzStorageAccountUserDelegationKeys",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5685,6 +5787,7 @@
   {
     "Command": "Get-AzStorageFileHandle",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5762,6 +5865,7 @@
   {
     "Command": "Close-AzStorageFileHandle",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5855,6 +5959,7 @@
   {
     "Command": "New-AzRmStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5918,6 +6023,7 @@
   {
     "Command": "Remove-AzRmStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -5985,6 +6091,7 @@
   {
     "Command": "Get-AzRmStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6034,6 +6141,7 @@
   {
     "Command": "Update-AzRmStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6107,6 +6215,7 @@
   {
     "Command": "Update-AzStorageFileServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6165,6 +6274,7 @@
   {
     "Command": "Get-AzStorageFileServiceProperty",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6200,6 +6310,7 @@
   {
     "Command": "Restore-AzRmStorageShare",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6259,6 +6370,7 @@
   {
     "Command": "Get-AzDataLakeGen2ChildItem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6314,6 +6426,7 @@
   {
     "Command": "Get-AzDataLakeGen2Item",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6341,6 +6454,7 @@
   {
     "Command": "New-AzDataLakeGen2Item",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6416,6 +6530,7 @@
   {
     "Command": "Move-AzDataLakeGen2Item",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6471,6 +6586,7 @@
   {
     "Command": "Remove-AzDataLakeGen2Item",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6526,6 +6642,7 @@
   {
     "Command": "Update-AzDataLakeGen2Item",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6593,6 +6710,7 @@
   {
     "Command": "Set-AzDataLakeGen2ItemAclObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6621,6 +6739,7 @@
   {
     "Command": "Get-AzDataLakeGen2ItemContent",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6684,6 +6803,7 @@
   {
     "Command": "Invoke-AzStorageAccountFailover",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6735,6 +6855,7 @@
   {
     "Command": "Get-AzStorageBlobQueryResult",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6830,6 +6951,7 @@
   {
     "Command": "New-AzStorageBlobQueryConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6870,6 +6992,7 @@
   {
     "Command": "New-AzStorageObjectReplicationPolicyRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6906,6 +7029,7 @@
   {
     "Command": "Set-AzStorageObjectReplicationPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -6968,6 +7092,7 @@
   {
     "Command": "Get-AzStorageObjectReplicationPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7002,6 +7127,7 @@
   {
     "Command": "Remove-AzStorageObjectReplicationPolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7056,6 +7182,7 @@
   {
     "Command": "Enable-AzStorageBlobRestorePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7113,6 +7240,7 @@
   {
     "Command": "Disable-AzStorageBlobRestorePolicy",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7164,6 +7292,7 @@
   {
     "Command": "New-AzStorageBlobRangeToRestore",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7188,6 +7317,7 @@
   {
     "Command": "Restore-AzStorageBlobRange",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7250,6 +7380,7 @@
   {
     "Command": "Set-AzDataLakeGen2AclRecursive",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7313,6 +7444,7 @@
   {
     "Command": "Update-AzDataLakeGen2AclRecursive",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7376,6 +7508,7 @@
   {
     "Command": "Remove-AzDataLakeGen2AclRecursive",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7439,6 +7572,7 @@
   {
     "Command": "Get-AzStorageContainerAcl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7493,6 +7627,7 @@
   {
     "Command": "Start-CopyAzureStorageBlob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7654,6 +7789,7 @@
   {
     "Command": "Stop-CopyAzureStorageBlob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7727,6 +7863,7 @@
   {
     "Command": "Enable-AzStorageSoftDelete",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7768,6 +7905,7 @@
   {
     "Command": "Disable-AzStorageSoftDelete",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7803,6 +7941,7 @@
   {
     "Command": "New-AzDatalakeGen2FileSystem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7851,6 +7990,7 @@
   {
     "Command": "Remove-AzDatalakeGen2FileSystem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7913,6 +8053,7 @@
   {
     "Command": "Get-AzDatalakeGen2FileSystem",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [
@@ -7967,6 +8108,7 @@
   {
     "Command": "New-AzDataLakeGen2ItemAclObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Storage",
     "Version": "3.1.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.StorageSync.1.4.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.StorageSync.1.4.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Invoke-AzStorageSyncCompatibilityCheck",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "New-AzStorageSyncService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -86,6 +88,7 @@
   {
     "Command": "Get-AzStorageSyncService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -112,6 +115,7 @@
   {
     "Command": "Set-AzStorageSyncService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -172,6 +176,7 @@
   {
     "Command": "Remove-AzStorageSyncService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -230,6 +235,7 @@
   {
     "Command": "New-AzStorageSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -286,6 +292,7 @@
   {
     "Command": "Get-AzStorageSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -330,6 +337,7 @@
   {
     "Command": "Remove-AzStorageSyncGroup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -394,6 +402,7 @@
   {
     "Command": "New-AzStorageSyncCloudEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -472,6 +481,7 @@
   {
     "Command": "Get-AzStorageSyncCloudEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -520,6 +530,7 @@
   {
     "Command": "Remove-AzStorageSyncCloudEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -586,6 +597,7 @@
   {
     "Command": "New-AzStorageSyncServerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -686,6 +698,7 @@
   {
     "Command": "Get-AzStorageSyncServerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -734,6 +747,7 @@
   {
     "Command": "Remove-AzStorageSyncServerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -800,6 +814,7 @@
   {
     "Command": "Set-AzStorageSyncServerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -883,6 +898,7 @@
   {
     "Command": "Invoke-AzStorageSyncFileRecall",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -958,6 +974,7 @@
   {
     "Command": "Register-AzStorageSyncServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -1012,6 +1029,7 @@
   {
     "Command": "Unregister-AzStorageSyncServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -1076,6 +1094,7 @@
   {
     "Command": "Get-AzStorageSyncServer",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -1120,6 +1139,7 @@
   {
     "Command": "Reset-AzStorageSyncServerCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [
@@ -1174,6 +1194,7 @@
   {
     "Command": "Invoke-AzStorageSyncChangeDetection",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StorageSync",
     "Version": "1.4.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.StreamAnalytics.1.0.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.StreamAnalytics.1.0.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzStreamAnalyticsFunction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "Get-AzStreamAnalyticsDefaultFunctionDefinition",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -62,6 +64,7 @@
   {
     "Command": "New-AzStreamAnalyticsFunction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -110,6 +113,7 @@
   {
     "Command": "Remove-AzStreamAnalyticsFunction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -150,6 +154,7 @@
   {
     "Command": "Test-AzStreamAnalyticsFunction",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -178,6 +183,7 @@
   {
     "Command": "Get-AzStreamAnalyticsInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -206,6 +212,7 @@
   {
     "Command": "New-AzStreamAnalyticsInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -254,6 +261,7 @@
   {
     "Command": "Remove-AzStreamAnalyticsInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -294,6 +302,7 @@
   {
     "Command": "Test-AzStreamAnalyticsInput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -322,6 +331,7 @@
   {
     "Command": "Get-AzStreamAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -350,6 +360,7 @@
   {
     "Command": "New-AzStreamAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -394,6 +405,7 @@
   {
     "Command": "Remove-AzStreamAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -430,6 +442,7 @@
   {
     "Command": "Start-AzStreamAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -462,6 +475,7 @@
   {
     "Command": "Stop-AzStreamAnalyticsJob",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -486,6 +500,7 @@
   {
     "Command": "Get-AzStreamAnalyticsOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -514,6 +529,7 @@
   {
     "Command": "New-AzStreamAnalyticsOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -562,6 +578,7 @@
   {
     "Command": "Remove-AzStreamAnalyticsOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -602,6 +619,7 @@
   {
     "Command": "Test-AzStreamAnalyticsOutput",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -630,6 +648,7 @@
   {
     "Command": "Get-AzStreamAnalyticsQuota",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -650,6 +669,7 @@
   {
     "Command": "Get-AzStreamAnalyticsTransformation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [
@@ -678,6 +698,7 @@
   {
     "Command": "New-AzStreamAnalyticsTransformation",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.StreamAnalytics",
     "Version": "1.0.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Support.1.0.0.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Support.1.0.0.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzSupportService",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -24,6 +25,7 @@
   {
     "Command": "Get-AzSupportProblemClassification",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -56,6 +58,7 @@
   {
     "Command": "Get-AzSupportTicket",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -92,6 +95,7 @@
   {
     "Command": "Get-AzSupportTicketCommunication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -136,6 +140,7 @@
   {
     "Command": "New-AzSupportTicketCommunication",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -192,6 +197,7 @@
   {
     "Command": "New-AzSupportTicket",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -304,6 +310,7 @@
   {
     "Command": "New-AzSupportContactProfileObject",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [
@@ -368,6 +375,7 @@
   {
     "Command": "Update-AzSupportTicket",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Support",
     "Version": "1.0.0",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.TrafficManager.1.0.4.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.TrafficManager.1.0.4.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Add-AzTrafficManagerCustomHeaderToEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -42,6 +43,7 @@
   {
     "Command": "Remove-AzTrafficManagerCustomHeaderFromEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -78,6 +80,7 @@
   {
     "Command": "Add-AzTrafficManagerCustomHeaderToProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -118,6 +121,7 @@
   {
     "Command": "Remove-AzTrafficManagerCustomHeaderFromProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -154,6 +158,7 @@
   {
     "Command": "Disable-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -206,6 +211,7 @@
   {
     "Command": "Enable-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -242,6 +248,7 @@
   {
     "Command": "Set-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -262,6 +269,7 @@
   {
     "Command": "Get-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -298,6 +306,7 @@
   {
     "Command": "Remove-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -350,6 +359,7 @@
   {
     "Command": "New-AzTrafficManagerEndpoint",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -422,6 +432,7 @@
   {
     "Command": "Remove-AzTrafficManagerEndpointConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -446,6 +457,7 @@
   {
     "Command": "Add-AzTrafficManagerEndpointConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -514,6 +526,7 @@
   {
     "Command": "Add-AzTrafficManagerExpectedStatusCodeRange",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -554,6 +567,7 @@
   {
     "Command": "Remove-AzTrafficManagerExpectedStatusCodeRange",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -590,6 +604,7 @@
   {
     "Command": "Add-AzTrafficManagerIpAddressRange",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -634,6 +649,7 @@
   {
     "Command": "Remove-AzTrafficManagerIpAddressRange",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -670,6 +686,7 @@
   {
     "Command": "Disable-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -714,6 +731,7 @@
   {
     "Command": "Enable-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -742,6 +760,7 @@
   {
     "Command": "Remove-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -786,6 +805,7 @@
   {
     "Command": "Set-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -806,6 +826,7 @@
   {
     "Command": "Get-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [
@@ -830,6 +851,7 @@
   {
     "Command": "New-AzTrafficManagerProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.TrafficManager",
     "Version": "1.0.4",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Websites.2.1.1.Cmdlets.json
+++ b/powershell-module/Az.Tools.Migration/Resources/ModuleSpecs/Az/5.2.0/Az.Websites.2.1.1.Cmdlets.json
@@ -2,6 +2,7 @@
   {
     "Command": "Get-AzAppServicePlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -30,6 +31,7 @@
   {
     "Command": "Set-AzAppServicePlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -86,6 +88,7 @@
   {
     "Command": "New-AzAppServicePlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -158,6 +161,7 @@
   {
     "Command": "Remove-AzAppServicePlan",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -206,6 +210,7 @@
   {
     "Command": "Get-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -238,6 +243,7 @@
   {
     "Command": "Get-AzWebAppSlotConfigName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -266,6 +272,7 @@
   {
     "Command": "Get-AzWebAppSlotPublishingProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -310,6 +317,7 @@
   {
     "Command": "New-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -390,6 +398,7 @@
   {
     "Command": "Remove-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -442,6 +451,7 @@
   {
     "Command": "Reset-AzWebAppSlotPublishingProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -474,6 +484,7 @@
   {
     "Command": "Restart-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -506,6 +517,7 @@
   {
     "Command": "Set-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -650,6 +662,7 @@
   {
     "Command": "Set-AzWebAppSlotConfigName",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -694,6 +707,7 @@
   {
     "Command": "Start-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -726,6 +740,7 @@
   {
     "Command": "Stop-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -758,6 +773,7 @@
   {
     "Command": "Switch-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -814,6 +830,7 @@
   {
     "Command": "New-AzWebAppDatabaseBackupSetting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -846,6 +863,7 @@
   {
     "Command": "Restore-AzWebAppBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -902,6 +920,7 @@
   {
     "Command": "Get-AzWebAppCertificate",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -926,6 +945,7 @@
   {
     "Command": "Get-AzWebAppSSLBinding",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -962,6 +982,7 @@
   {
     "Command": "New-AzWebAppSSLBinding",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1014,6 +1035,7 @@
   {
     "Command": "Remove-AzWebAppSSLBinding",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1070,6 +1092,7 @@
   {
     "Command": "Edit-AzWebAppBackupConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1130,6 +1153,7 @@
   {
     "Command": "Get-AzWebAppBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1166,6 +1190,7 @@
   {
     "Command": "Get-AzWebAppBackupConfiguration",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1198,6 +1223,7 @@
   {
     "Command": "Get-AzWebAppBackupList",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1230,6 +1256,7 @@
   {
     "Command": "Get-AzWebAppPublishingProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1270,6 +1297,7 @@
   {
     "Command": "Get-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1302,6 +1330,7 @@
   {
     "Command": "New-AzWebAppBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1346,6 +1375,7 @@
   {
     "Command": "Remove-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1394,6 +1424,7 @@
   {
     "Command": "New-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1503,6 +1534,7 @@
   {
     "Command": "Remove-AzWebAppBackup",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1539,6 +1571,7 @@
   {
     "Command": "Reset-AzWebAppPublishingProfile",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1567,6 +1600,7 @@
   {
     "Command": "Restart-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1595,6 +1629,7 @@
   {
     "Command": "Set-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1735,6 +1770,7 @@
   {
     "Command": "Start-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1763,6 +1799,7 @@
   {
     "Command": "Stop-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1791,6 +1828,7 @@
   {
     "Command": "Get-AzWebAppSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1827,6 +1865,7 @@
   {
     "Command": "Restore-AzWebAppSnapshot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1891,6 +1930,7 @@
   {
     "Command": "Get-AzDeletedWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -1923,6 +1963,7 @@
   {
     "Command": "Restore-AzDeletedWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2007,6 +2048,7 @@
   {
     "Command": "Get-AzWebAppContainerContinuousDeploymentUrl",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2039,6 +2081,7 @@
   {
     "Command": "Enter-AzWebAppContainerPSSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2091,6 +2134,7 @@
   {
     "Command": "New-AzWebAppContainerPSSession",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2139,6 +2183,7 @@
   {
     "Command": "New-AzWebAppAzureStoragePath",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2191,6 +2236,7 @@
   {
     "Command": "Publish-AzWebApp",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2247,6 +2293,7 @@
   {
     "Command": "Get-AzWebAppAccessRestrictionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2275,6 +2322,7 @@
   {
     "Command": "Add-AzWebAppAccessRestrictionRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2367,6 +2415,7 @@
   {
     "Command": "Remove-AzWebAppAccessRestrictionRule",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2443,6 +2492,7 @@
   {
     "Command": "Update-AzWebAppAccessRestrictionConfig",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2495,6 +2545,7 @@
   {
     "Command": "Add-AzWebAppTrafficRouting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2535,6 +2586,7 @@
   {
     "Command": "Remove-AzWebAppTrafficRouting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2579,6 +2631,7 @@
   {
     "Command": "Get-AzWebAppTrafficRouting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2619,6 +2672,7 @@
   {
     "Command": "Update-AzWebAppTrafficRouting",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [
@@ -2659,6 +2713,7 @@
   {
     "Command": "Swap-AzWebAppSlot",
     "IsAlias": false,
+    "SupportsDynamicParameters": false,
     "SourceModule": "Az.Websites",
     "Version": "2.1.1",
     "Parameters": [

--- a/powershell-module/Az.Tools.Migration/Tests/Functions/Public/New-AzUpgradeModulePlan.tests.ps1
+++ b/powershell-module/Az.Tools.Migration/Tests/Functions/Public/New-AzUpgradeModulePlan.tests.ps1
@@ -299,7 +299,7 @@ InModuleScope -ModuleName Az.Tools.Migration -ScriptBlock {
 
             $results[0].UpgradeType.ToString() | Should Be 'CmdletParameter'
             $results[0].PlanResult.ToString() | Should Be "WarningDynamicParameter"
-            $results[0].PlanResultReason.Contains("Parameter is dynamic") | Should Be $true
+            $results[0].PlanResultReason.Contains("supports dynamic parameters") | Should Be $true
             $results[0].PlanSeverity.ToString() | Should Be 'Warning'
 
             $results[1].UpgradeType.ToString() | Should Be 'Cmdlet'

--- a/powershell-module/Scripts/New-AzCmdletSpec.ps1
+++ b/powershell-module/Scripts/New-AzCmdletSpec.ps1
@@ -55,6 +55,9 @@ function New-ModuleCommandDefinitionsFile
     .PARAMETER OutputDirectory
         Specify the folder location to save the new definitions file.
 
+    .PARAMETER MinimumVersion
+        Specify to use a 'minimumversion' flag when searching, instead of required version.
+
     .EXAMPLE
         PS C:\> New-ModuleCommandDefinitionsFile -ModuleName "Azure.Storage" -ModuleVersion "5.2.0" -OutputDirectory "C:\users\user\desktop"
         Creates a new module definition json file for the given module.
@@ -81,17 +84,30 @@ function New-ModuleCommandDefinitionsFile
             HelpMessage="Specify the folder location to save the new definitions file.")]
         [System.String]
         [ValidateNotNullOrEmpty()]
-        $OutputDirectory
+        $OutputDirectory,
+
+        [Parameter(
+            Mandatory=$false,
+            HelpMessage="Use the -MinimumVersion flag when searching for the module.")]
+        [Switch]
+        $MinimumVersion
     )
     Process
     {
         $defaultParamNames = @("Debug", "ErrorAction", "ErrorVariable", "InformationAction", "InformationVariable", "OutVariable", "OutBuffer", "PipelineVariable", "Verbose", "WarningAction", "WarningVariable")
 
-        $module = Get-Module -ListAvailable | Where-Object { $_.Name -eq $ModuleName -and $_.Version -eq $ModuleVersion } | Select-Object -First 1
+        if ($PSBoundParameters.ContainsKey('MinimumVersion'))
+        {
+            $module = Get-Module -ListAvailable | Where-Object { $_.Name -eq $ModuleName -and $_.Version -ge $ModuleVersion } | Select-Object -First 1
+        }
+        else
+        {
+            $module = Get-Module -ListAvailable | Where-Object { $_.Name -eq $ModuleName -and $_.Version -eq $ModuleVersion } | Select-Object -First 1
+        }
 
         if ($module -eq $null)
         {
-            throw "No module was found that matches the specified name and version."
+            throw "No module was found that matches the specified name [$ModuleName] and version number [$ModuleVersion]."
         }
 
         $exportedCommandResults = New-Object -TypeName 'System.collections.Generic.List[CommandDefinition]'
@@ -197,7 +213,14 @@ foreach ($importStatement in $moduleImportStatements)
 
         Write-Host "Building module spec for $SubModuleName $SubModuleVersion"
 
-        New-ModuleCommandDefinitionsFile -ModuleName $SubModuleName -ModuleVersion $SubModuleVersion -OutputDirectory $OutputDirectory
+        if ($importStatement -match "MinimumVersion")
+        {
+            New-ModuleCommandDefinitionsFile -ModuleName $SubModuleName -ModuleVersion $SubModuleVersion -OutputDirectory $OutputDirectory -MinimumVersion
+        }
+        else
+        {
+            New-ModuleCommandDefinitionsFile -ModuleName $SubModuleName -ModuleVersion $SubModuleVersion -OutputDirectory $OutputDirectory
+        }
     }
 }
 

--- a/powershell-module/Scripts/New-AzCmdletSpec.ps1
+++ b/powershell-module/Scripts/New-AzCmdletSpec.ps1
@@ -106,6 +106,7 @@ function New-ModuleCommandDefinitionsFile
             $definition.Command = $exportedCommandValue.Name
             $definition.SourceModule = $exportedCommandValue.ModuleName
             $definition.Version = $exportedCommandValue.Version
+            $definition.Parameters = New-Object -TypeName 'System.Collections.Generic.List[CommandDefinitionParameter]'
 
             if ($exportedCommandValue.Value.CommandType -eq "Cmdlet")
             {
@@ -141,6 +142,13 @@ function New-ModuleCommandDefinitionsFile
 
                         $definition.Parameters.Add($moduleCommandParamDefinition)
                     }
+                }
+
+                # does this command support dynamic parameters?
+                $dynamicImplemented = $moduleCommand.ImplementingType.ImplementedInterfaces | Where-Object -FilterScript { $_.Name -eq 'IDynamicParameters' }
+                if ($dynamicImplemented -ne $null)
+                {
+                    $definition.SupportsDynamicParameters = $true
                 }
 
                 $exportedCommandResults.Add($definition)


### PR DESCRIPTION
### Changes

* Az Cmdlets that implement `IDynamicParameters` will now produce a friendly warning, instead of an error, for any custom/dynamic parameters used in scripts. This means around 30 cmdlets in Az are supported, not just the resource group deployment cmdlet. The list of cmdlets that support `IDynamicParameters` is automatically detected by the module spec generation script, so there is no need to maintain a list.

* An unrelated performance improvement for `Get-AzUpgradeCmdletSpec`: I moved the `CommandDefinition.Parameters` collection initialization out of the constructor to avoid unneccessary new object allocations before deserialization. This cmdlet should be noticeably faster now.

* Bug fix for New-AzCmdletSpec: handle both 'MinimumVersion' and 'RequiredVersion' types of imports referenced by Az.psm1

### Screenshots

Additional test coverage for IDynamicParameters

![image](https://user-images.githubusercontent.com/9817416/104702331-b382ac00-56ca-11eb-9a54-a8dcc07e8a9f.png)

New plan message examples: one 'ready to upgrade' for the cmdlet itself, and one 'dynamic parameter warning' for the dynamic parameter used.

![image](https://user-images.githubusercontent.com/9817416/104702758-4f141c80-56cb-11eb-8263-a0a7e0c486dd.png)
