### PR TITLE
support azurerm 6.13.2

### DIFF
--- a/docs/quickstart-migrate-azurerm-to-az-automatically.md
+++ b/docs/quickstart-migrate-azurerm-to-az-automatically.md
@@ -20,7 +20,7 @@ Report feedback and issues about the Az.Tools.Migration PowerShell module via
 
 ## Requirements
 
-* Update your existing PowerShell scripts to the latest version of the [AzureRM PowerShell module (6.13.1)](https://github.com/Azure/azure-powershell/releases/tag/v6.13.1-November2018).
+* Update your existing PowerShell scripts to AzureRM PowerShell module version [6.13.1](https://github.com/Azure/azure-powershell/releases/tag/v6.13.1-November2018) or [6.13.2](https://github.com/Azure/azure-powershell/releases/tag/v6.13.2-March2021).
 * Install the Az.Tools.Migration PowerShell module.
 
   ```powershell

--- a/powershell-module/Az.Tools.Migration/Az.Tools.Migration.psd1
+++ b/powershell-module/Az.Tools.Migration/Az.Tools.Migration.psd1
@@ -3,7 +3,7 @@
     RootModule = 'Az.Tools.Migration.psm1'
 
     # Version number of this module.
-    ModuleVersion = '11.0.1'
+    ModuleVersion = '11.0.2'
 
     # Supported PSEditions
     CompatiblePSEditions = 'Core', 'Desktop'
@@ -108,7 +108,7 @@
             # IconUri = ''
 
             # ReleaseNotes of this module
-            ReleaseNotes = "* Fixed bug DataFactory cmdlet name cannot be recognized [#117]"
+            ReleaseNotes = "* Added Support for AzureRm version 6.13.2 [#132]"
         }
     }
 

--- a/powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1
+++ b/powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1
@@ -92,10 +92,8 @@ function Find-AzUpgradeCommandReference
     {
         # write warning if given azurerm version is not supported
         $supportedAzureRmVersion = @('6.13.1', '6.13.2')
-        if (-not $supportedAzureRmVersion.Contains($FromAzureRmVersion)) {
-            Write-Error "AzureRm $FromAzureRmVersion is currently not supported. Supported AzureRm versions include '6.13.1', '6.13.2'." -ErrorAction Stop
-        } else {
-            $FromAzureRmVersion = '6.13.1'
+        if (-not $supportedAzureRmVersion.Contains($AzureRmVersion)) {
+            Write-Error "AzureRm $AzureRmVersion is currently not supported. Supported AzureRm versions include '6.13.1', '6.13.2'." -ErrorAction Stop
         }
 
         $cmdStarted = Get-Date

--- a/powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1
+++ b/powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1
@@ -69,13 +69,12 @@ function Find-AzUpgradeCommandReference
         [Parameter(
             Mandatory=$true,
             ParameterSetName="ByFileAndModuleVersion",
-            HelpMessage="Specify the AzureRM module version used in your existing PowerShell file(s)/modules.")]
+            HelpMessage="Specify the AzureRM module version used in your existing PowerShell file(s)/modules. Supported versions include: '6.13.1', '6.13.2'")]
         [Parameter(
             Mandatory=$true,
             ParameterSetName="ByDirectoryAndModuleVersion",
-            HelpMessage="Specify the AzureRM module version used in your existing PowerShell file(s)/modules.")]
+            HelpMessage="Specify the AzureRM module version used in your existing PowerShell file(s)/modules. Supported versions include: '6.13.1', '6.13.2'")]
         [System.String]
-        [ValidateSet("6.13.1")]
         $AzureRmVersion,
 
         [Parameter(
@@ -91,6 +90,14 @@ function Find-AzUpgradeCommandReference
     )
     Process
     {
+        # write warning if given azurerm version is not supported
+        $supportedAzureRmVersion = @('6.13.1', '6.13.2')
+        if (-not $supportedAzureRmVersion.Contains($FromAzureRmVersion)) {
+            Write-Error "AzureRm $FromAzureRmVersion is currently not supported. Supported AzureRm versions include '6.13.1', '6.13.2'." -ErrorAction Stop
+        } else {
+            $FromAzureRmVersion = '6.13.1'
+        }
+
         $cmdStarted = Get-Date
 
         if ($PSBoundParameters.ContainsKey('AzureRmModuleSpec') -eq $false)

--- a/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
+++ b/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
@@ -74,13 +74,12 @@ function New-AzUpgradeModulePlan
         [Parameter(
             Mandatory=$true,
             ParameterSetName="FromNewSearchByFile",
-            HelpMessage='Specify the Az module version to upgrade to.')]
+            HelpMessage='Specify the Az module version to upgrade to. Supported versions include: "6.13.1", "6.13.2"')]
         [Parameter(
             Mandatory=$true,
             ParameterSetName="FromNewSearchByDirectory",
-            HelpMessage='Specify the Az module version to upgrade to.')]
+            HelpMessage='Specify the Az module version to upgrade to. Supported versions include: "6.13.1", "6.13.2"')]
         [System.String]
-        [ValidateSet('6.13.1')]
         $FromAzureRmVersion,
 
         [Parameter(
@@ -120,6 +119,14 @@ function New-AzUpgradeModulePlan
     )
     Process
     {
+        # write warning if given azurerm version is not supported
+        $supportedAzureRmVersion = @('6.13.1', '6.13.2')
+        if (-not $supportedAzureRmVersion.Contains($FromAzureRmVersion)) {
+            Write-Error "AzureRm $FromAzureRmVersion is currently not supported. Supported AzureRm versions include '6.13.1', '6.13.2'." -ErrorAction Stop
+        } else {
+            $FromAzureRmVersion = '6.13.1'
+        }
+
         $cmdStarted = Get-Date
 
         $versionPath = Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath "\Resources\ModuleSpecs\Az\$ToAzVersion"

--- a/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
+++ b/powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1
@@ -123,8 +123,6 @@ function New-AzUpgradeModulePlan
         $supportedAzureRmVersion = @('6.13.1', '6.13.2')
         if (-not $supportedAzureRmVersion.Contains($FromAzureRmVersion)) {
             Write-Error "AzureRm $FromAzureRmVersion is currently not supported. Supported AzureRm versions include '6.13.1', '6.13.2'." -ErrorAction Stop
-        } else {
-            $FromAzureRmVersion = '6.13.1'
         }
 
         $cmdStarted = Get-Date

--- a/powershell-module/ChangeLog.md
+++ b/powershell-module/ChangeLog.md
@@ -18,6 +18,8 @@
         - Additional information about change #1
 -->
 ## Upcoming Release
+## 11.0.2
+* Added Support for AzureRm version 6.13.2 [#132]
 
 ## 11.0.1
 * Fixed bug DataFactory cmdlet name cannot be recognized [#117]

--- a/powershell-module/help/Find-AzUpgradeCommandReference.md
+++ b/powershell-module/help/Find-AzUpgradeCommandReference.md
@@ -95,7 +95,7 @@ Accept wildcard characters: False
 
 ### -AzureRmVersion
 
-Specifies the **AzureRM** module version used in your existing PowerShell file(s) or modules.
+Specifies the **AzureRM** module version used in your existing PowerShell file(s) or modules. Supported versions include: '6.13.1', '6.13.2'
 
 ```yaml
 Type: System.String

--- a/powershell-module/help/New-AzUpgradeModulePlan.md
+++ b/powershell-module/help/New-AzUpgradeModulePlan.md
@@ -199,7 +199,7 @@ Accept wildcard characters: False
 
 ### -FromAzureRmVersion
 
-Specifies the **AzureRM** module version used in your existing PowerShell scripts(s) or modules.
+Specifies the **AzureRM** module version used in your existing PowerShell scripts(s) or modules. Supported versions include: "6.13.1", "6.13.2"
 
 ```yaml
 Type: System.String


### PR DESCRIPTION
This pull request primarily introduces support for AzureRm version 6.13.2 in the `Az.Tools.Migration` PowerShell module. The most significant changes include updating the `ModuleVersion` and `ReleaseNotes` in the module manifest, modifying the help messages and validation sets for the `AzureRmVersion` parameter in the `Find-AzUpgradeCommandReference` and `New-AzUpgradeModulePlan` functions, and adding error handling for unsupported AzureRm versions in these functions.

Module Manifest Changes:
* [`powershell-module/Az.Tools.Migration/Az.Tools.Migration.psd1`](diffhunk://#diff-2b748e1abb90839e653bdb1aca391259d78f3d0ff2ff302f80c2b5a195afc9c7L6-R6): Updated the `ModuleVersion` from '11.0.1' to '11.0.2' and changed the `ReleaseNotes` to reflect the added support for AzureRm version 6.13.2. [[1]](diffhunk://#diff-2b748e1abb90839e653bdb1aca391259d78f3d0ff2ff302f80c2b5a195afc9c7L6-R6) [[2]](diffhunk://#diff-2b748e1abb90839e653bdb1aca391259d78f3d0ff2ff302f80c2b5a195afc9c7L111-R111)

Function Parameter Changes:
* [`powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1`](diffhunk://#diff-f8fd770fb923ebf81c435acc4c8e47e491a8f5d95e867d81f40385c3c794d0cbL72-L78): Updated the `HelpMessage` and removed the `ValidateSet` for the `AzureRmVersion` parameter to include support for '6.13.2'.
* [`powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1`](diffhunk://#diff-3d12ceb405294582c6b22fd65703a54f2c79d5580f96e4e9106139a5942ed6ffL77-L83): Updated the `HelpMessage` for the `FromAzureRmVersion` parameter to include support for '6.13.2'.

Error Handling for Unsupported Versions:
* [`powershell-module/Az.Tools.Migration/Functions/Public/Find-AzUpgradeCommandReference.ps1`](diffhunk://#diff-f8fd770fb923ebf81c435acc4c8e47e491a8f5d95e867d81f40385c3c794d0cbR93-R100): Added a check for unsupported AzureRm versions and a corresponding error message.
* [`powershell-module/Az.Tools.Migration/Functions/Public/New-AzUpgradeModulePlan.ps1`](diffhunk://#diff-3d12ceb405294582c6b22fd65703a54f2c79d5580f96e4e9106139a5942ed6ffR122-R129): Added a similar check for unsupported AzureRm versions and a corresponding error message.

Documentation Updates:
* [`powershell-module/ChangeLog.md`](diffhunk://#diff-547b88f6b1aa5959a67594a5ffed588b6568698d42da10962c01e0cdee3a6516R21-R22): Updated the change log to reflect the new module version and support for AzureRm version 6.13.2.
* `powershell-module/help/Find-AzUpgradeCommandReference.md` and `powershell-module/help/New-AzUpgradeModulePlan.md`: Updated the documentation for the `AzureRmVersion` and `FromAzureRmVersion` parameters to include the newly supported version '6.13.2'. [[1]](diffhunk://#diff-ff441a6be8e8bc7ff3666e2b6fb60c8d986b5e4ce974e58059ed19a7ab324db9L98-R98) [[2]](diffhunk://#diff-5334431641f0595a9335b7ee5a24d967a6d2de154863b9cd68ed420140772ba3L202-R202)